### PR TITLE
Merge temporary fixes from unit-tests into master

### DIFF
--- a/planning/todos.md
+++ b/planning/todos.md
@@ -7,3 +7,4 @@ TODO: sync code does not respect SIGINT
 TODO: type hints
 TODO: README + docs
 TODO: preprocessors
+TODO: base namespace (connect, close, port) and make it generic TClientPort

--- a/planning/todos.md
+++ b/planning/todos.md
@@ -5,10 +5,7 @@ TODO: unit tests!
 TODO: single vs double underscore naming
 TODO: subclasses of clientport with restrictions on request schemas?
 TODO: clean up streamable iterators
-
 TODO: sync code does not respect SIGINT
-TODO: code hangs on RPC errors
-TODO: make return types Optional for error handling
-TODO: clean up import statements, alphabetize
-TODO: type hints, abstractmethods
+TODO: type hints
 TODO: README + docs
+TODO: preprocessors

--- a/planning/todos.md
+++ b/planning/todos.md
@@ -1,8 +1,6 @@
-TODO: verbose and robust error handling
-TODO: translate logger messages instead of using print statements
 TODO: rewrite docstrings because they still have copy/pasted typescript annotations
 TODO: unit tests!
-TODO: single vs double underscore naming
+TODO: "private" methods
 TODO: subclasses of clientport with restrictions on request schemas?
 TODO: clean up streamable iterators
 TODO: sync code does not respect SIGINT

--- a/src/lmstudio_sdk/backend/client/AsyncLMStudioClient.py
+++ b/src/lmstudio_sdk/backend/client/AsyncLMStudioClient.py
@@ -72,9 +72,13 @@ class AsyncLMStudioClient(LMStudioClient):
         self.create_ports(True)
 
         logger.info(f"Connecting to LM Studio server at {self.base_url}...")
-        await asyncio.gather(
-            self.llm.connect(), self.embedding.connect(), self.system.connect(), self.diagnostics.connect()
-        )
+        try:
+            await asyncio.gather(
+                self.llm.connect(), self.embedding.connect(), self.system.connect(), self.diagnostics.connect()
+            )
+        except ConnectionRefusedError:
+            logger.error(f"Failed to connect to LM Studio server at {self.base_url}.")
+            raise ValueError(f"Failed to connect to LM Studio server at {self.base_url}.")
         logger.info("Connected to LM Studio server.")
 
         return self

--- a/src/lmstudio_sdk/backend/client/LMStudioClient.py
+++ b/src/lmstudio_sdk/backend/client/LMStudioClient.py
@@ -67,6 +67,10 @@ class LMStudioClient(ABC):
         pass
 
     @abstractmethod
+    def connect(self):
+        pass
+
+    @abstractmethod
     def close(self):
         pass
 

--- a/src/lmstudio_sdk/backend/client/LMStudioClientFactory.py
+++ b/src/lmstudio_sdk/backend/client/LMStudioClientFactory.py
@@ -1,4 +1,5 @@
 import inspect
+from .LMStudioClient import LMStudioClient as LMStudioClientBase
 from .AsyncLMStudioClient import AsyncLMStudioClient
 from .SyncLMStudioClient import SyncLMStudioClient
 
@@ -8,7 +9,7 @@ def LMStudioClient(
     base_url: str | None = None,
     client_identifier: str | None = None,
     client_passkey: str | None = None,
-) -> AsyncLMStudioClient | SyncLMStudioClient:
+) -> LMStudioClientBase:
     """
     Constructs an instance of either `AsyncLMStudioClient` or `SyncLMStudioClient`. Just `await` for async!
     """
@@ -18,4 +19,4 @@ def LMStudioClient(
         if is_async
         else SyncLMStudioClient(base_url, client_identifier, client_passkey)
     )
-    return client.connect() if is_async else client
+    return client.connect()

--- a/src/lmstudio_sdk/backend/client/SyncLMStudioClient.py
+++ b/src/lmstudio_sdk/backend/client/SyncLMStudioClient.py
@@ -51,22 +51,29 @@ class SyncLMStudioClient(LMStudioClient):
         client_passkey: str | None,
     ):
         super().__init__(base_url, client_identifier, client_passkey)
+
+    def connect(self):
         if self.base_url is None:
             logger.warning("base_url is None. Attempting to guess base_url.")
             self.base_url = self._guess_base_url()
         self._validate_base_url_or_throw(self.base_url)
 
         self.create_ports(False)
-
         logger.info(f"Connecting to LM Studio server at {self.base_url}...")
-        self.llm.connect()
-        logger.debug("LLM port connected, connecting to embedding port...")
-        self.embedding.connect()
-        logger.debug("Embedding port connected, connecting to system port...")
-        self.system.connect()
-        logger.debug("System port connected, connecting to diagnostics port...")
-        self.diagnostics.connect()
-        logger.info("Connected to LM Studio server.")
+        try:
+            self.llm.connect()
+            logger.debug("LLM port connected, connecting to embedding port...")
+            self.embedding.connect()
+            logger.debug("Embedding port connected, connecting to system port...")
+            self.system.connect()
+            logger.debug("System port connected, connecting to diagnostics port...")
+            self.diagnostics.connect()
+            logger.info("Connected to LM Studio server.")
+        except ConnectionRefusedError:
+            logger.error(f"Failed to connect to LM Studio server at {self.base_url}.")
+            raise ValueError(f"Failed to connect to LM Studio server at {self.base_url}.")
+
+        return self
 
     def close(self):
         logger.info(f"Closing connection to LM Studio server at {self.base_url}...")

--- a/src/lmstudio_sdk/backend/communications/AsyncClientPort.py
+++ b/src/lmstudio_sdk/backend/communications/AsyncClientPort.py
@@ -120,7 +120,10 @@ class AsyncClientPort(BaseClientPort):
             raise RPCError(f"Error in RPC call: {result.get('error').get('title', 'Unknown error')}")
 
         result = result.get("result", result)
-        result.update({"extra": extra})
+        if isinstance(result, dict):
+            result.update({"extra": extra})
+        else:
+            result = {"result": result, "extra": extra}
         return result
 
 

--- a/src/lmstudio_sdk/backend/communications/ClientPort.py
+++ b/src/lmstudio_sdk/backend/communications/ClientPort.py
@@ -131,7 +131,10 @@ class ClientPort(BaseClientPort):
             raise RPCError(f"Error in RPC call: {result.get('error').get('title', 'Unknown error')}")
 
         result = result.get("result", result)
-        result.update({"extra": extra})
+        if isinstance(result, dict):
+            result.update({"extra": extra})
+        else:
+            result = {"result": result, "extra": extra}
         return result
 
 

--- a/src/lmstudio_sdk/backend/handles/LLMDynamicHandle.py
+++ b/src/lmstudio_sdk/backend/handles/LLMDynamicHandle.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Optional, Union, Tuple
+from typing import Callable, List, Tuple
 from functools import partial
 
 from ...dataclasses import (
@@ -19,7 +19,14 @@ from ...dataclasses import (
     ModelDescriptor,
     ModelSpecifier,
 )
-from ...utils import BufferedEvent, ChannelError, get_logger, pretty_print_error, sync_async_decorator
+from ...utils import (
+    BufferedEvent,
+    ChannelError,
+    get_logger,
+    number_to_checkbox_numeric,
+    pretty_print_error,
+    sync_async_decorator,
+)
 from .DynamicHandle import DynamicHandle
 
 
@@ -52,16 +59,6 @@ class LLMDynamicHandle(DynamicHandle):
 
     _internal_kv_config_stack = KVConfigStack(layers=[])
 
-    def number_to_checkbox_numeric(
-        self, value: Optional[float], unchecked_value: float, value_when_unchecked: float
-    ) -> Optional[Dict[str, Union[bool, float]]]:
-        if value is None:
-            return None
-        if value == unchecked_value:
-            return {"checked": False, "value": value_when_unchecked}
-        if value != unchecked_value:
-            return {"checked": True, "value": value}
-
     def prediction_config_to_kv_config(self, prediction_config: LLMPredictionConfig | None) -> KVConfig:
         fields = []
         if prediction_config is not None:
@@ -79,28 +76,28 @@ class LLMDynamicHandle(DynamicHandle):
                 fields.append(
                     {
                         "key": "max_predicted_tokens",
-                        "value": self.number_to_checkbox_numeric(prediction_config["max_predicted_tokens"], -1, 1),
+                        "value": number_to_checkbox_numeric(prediction_config["max_predicted_tokens"], -1, 1),
                     }
                 )
             if "repeat_penalty" in prediction_config:
                 fields.append(
                     {
                         "key": "repeat_penalty",
-                        "value": self.number_to_checkbox_numeric(prediction_config["repeat_penalty"], 1, 1),
+                        "value": number_to_checkbox_numeric(prediction_config["repeat_penalty"], 1, 1),
                     }
                 )
             if "min_p_sampling" in prediction_config:
                 fields.append(
                     {
                         "key": "min_p_sampling",
-                        "value": self.number_to_checkbox_numeric(prediction_config["min_p_sampling"], 0, 0.05),
+                        "value": number_to_checkbox_numeric(prediction_config["min_p_sampling"], 0, 0.05),
                     }
                 )
             if "top_p_sampling" in prediction_config:
                 fields.append(
                     {
                         "key": "top_p_sampling",
-                        "value": self.number_to_checkbox_numeric(prediction_config["top_p_sampling"], 1, 0.95),
+                        "value": number_to_checkbox_numeric(prediction_config["top_p_sampling"], 1, 0.95),
                     }
                 )
             if "cpu_threads" in prediction_config:

--- a/src/lmstudio_sdk/backend/namespaces/ModelNamespace.py
+++ b/src/lmstudio_sdk/backend/namespaces/ModelNamespace.py
@@ -141,11 +141,11 @@ class ModelNamespace(Generic[TClientPort, TLoadModelConfig, TDynamicHandle, TSpe
 
     @sync_async_decorator(obj_method="connect", process_result=lambda x: None)
     def connect(self) -> None:
-        pass
+        return {}
 
     @sync_async_decorator(obj_method="close", process_result=lambda x: None)
     def close(self) -> None:
-        pass
+        return {}
 
         """
         Load a model for inferencing. The first parameter is the model path. The second parameter is an

--- a/src/lmstudio_sdk/utils/__init__.py
+++ b/src/lmstudio_sdk/utils/__init__.py
@@ -3,7 +3,7 @@ from .BufferedEvent import BufferedEvent
 from .logger import get_logger, RECV, SEND, WRAPPER, WEBSOCKET
 from .PseudoFuture import PseudoFuture
 from .sync_async_decorator import pretty_print, pretty_print_error, sync_async_decorator
-from .utils import ChannelError, lms_default_ports, generate_random_base64, RPCError
+from .utils import ChannelError, lms_default_ports, generate_random_base64, number_to_checkbox_numeric, RPCError
 
 __all__ = [
     "AbortSignal",
@@ -12,6 +12,7 @@ __all__ = [
     "generate_random_base64",
     "get_logger",
     "lms_default_ports",
+    "number_to_checkbox_numeric",
     "pretty_print",
     "pretty_print_error",
     "PseudoFuture",

--- a/src/lmstudio_sdk/utils/utils.py
+++ b/src/lmstudio_sdk/utils/utils.py
@@ -1,5 +1,6 @@
 from base64 import b64encode
 from secrets import token_bytes
+from typing import Dict, Optional, Union
 
 
 lms_default_ports = [1234]
@@ -8,6 +9,17 @@ lms_default_ports = [1234]
 def generate_random_base64(byte_length: int) -> str:
     random_bytes = token_bytes(byte_length)
     return b64encode(random_bytes).decode("utf-8")
+
+
+def number_to_checkbox_numeric(
+    self, value: Optional[float], unchecked_value: float, value_when_unchecked: float
+) -> Optional[Dict[str, Union[bool, float]]]:
+    if value is None:
+        return None
+    if value == unchecked_value:
+        return {"checked": False, "value": value_when_unchecked}
+    if value != unchecked_value:
+        return {"checked": True, "value": value}
 
 
 class RPCError(Exception):

--- a/tests/ISSUES.md
+++ b/tests/ISSUES.md
@@ -1,0 +1,3 @@
+found:
+
+- guess base URL does not work in async client

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -1,9 +1,6 @@
 for each of sync, async:
 
-- test client constructors
 - test methods:
-  - system:
-    - list_downloaded_models
   - llm and embedding:
     - load
     - unload

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -1,0 +1,39 @@
+for each of sync, async:
+
+- test client constructors
+- test methods:
+  - system:
+    - list_downloaded_models
+  - llm and embedding:
+    - load
+    - unload
+    - list_loaded
+    - get
+    - unstable_get_any
+    - unstable_get_or_load
+  - embedding handles:
+    - get_model_info
+    - get_load_config
+    - embed_string
+    - unstable_get_context_length
+    - unstable_get_eval_batch_size
+    - unstable_tokenize
+  - llm handles:
+    - get_model_info
+    - get_load_config
+    - complete
+    - respond
+    - predict
+    - unstable_get_context_length
+    - unstable_apply_prompt_template
+    - unstable_tokenize
+    - unstable_count_tokens
+  - aborting model load and any prediction process
+  - getting response directly and iterating over chunks
+
+::how much of these can actually be unit tests and how much
+will require qualitative review?
+-> git LFS or submodule, ~~package a small embedding model~~ use packaged nomic and package an LLM and then test by pointing LM Studio to the packaged models folder
+::should we compare against a benchmark test suite in ts?
+-> yes: try static and dynamic test kits
+also ensure you set generation to deterministic

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,11 +1,10 @@
-from lmstudio_sdk import LMStudioClient, logger, RECV
+from ..src.lmstudio_sdk import LMStudioClient, logger, RECV
 import asyncio
 
 logger.setLevel(RECV)
 
 
 async def main():
-    # TODO: your errors are indented
     llm_client = await LMStudioClient(is_async=True, base_url="ws://localhost:1234")
     try:
         # model_path = "lmstudio-community/gemma-2-2b-it-GGUF/gemma-2-2b-it-Q8_0.gguf"

--- a/tests/unittests/async/system.py
+++ b/tests/unittests/async/system.py
@@ -1,0 +1,43 @@
+import unittest
+from lmstudio_sdk import LMStudioClient
+
+
+class TestSystem(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        # TODO: remove base URL
+        self.client = await LMStudioClient(base_url="ws://localhost:1234")
+
+    async def test_create_invalid_client_with_bad_scheme(self) -> None:
+        with self.assertRaises(ValueError):
+            await LMStudioClient(base_url="http://localhost:1234")
+
+    async def test_create_invalid_client_with_bad_query(self) -> None:
+        with self.assertRaises(ValueError):
+            await LMStudioClient(base_url="ws://localhost:1234?query=1234")
+
+    async def test_create_invalid_client_with_bad_fragment(self) -> None:
+        with self.assertRaises(ValueError):
+            await LMStudioClient(base_url="ws://localhost:1234#fragment")
+
+    async def test_create_invalid_client_with_bad_username(self) -> None:
+        with self.assertRaises(ValueError):
+            await LMStudioClient(base_url="ws://username@localhost:1234")
+
+    async def test_create_invalid_client_with_bad_password(self) -> None:
+        with self.assertRaises(ValueError):
+            await LMStudioClient(base_url="ws://username:password@localhost:1234")
+
+    async def test_create_invalid_client_with_bad_trailing_slash(self) -> None:
+        with self.assertRaises(ValueError):
+            await LMStudioClient(base_url="ws://localhost:1234/")
+
+    async def test_create_invalid_client_with_bad_url(self) -> None:
+        with self.assertRaises(ValueError):
+            await LMStudioClient(base_url="ws://localhost:019234")
+
+    async def test_list_downloaded_models(self) -> None:
+        result = await self.client.system.list_downloaded_models()
+        self.assertIsInstance(result, list)
+
+    async def asyncTearDown(self) -> None:
+        await self.client.close()


### PR DESCRIPTION
Temporarily merging fixes from the `unit-tests` branch into `master` so I can work on refactoring the async/sync distinction and documentation alongside, since these changes are not pertinent only to testing. These fixes are parity with lmstudio.js commit #86 for magic numbers and handling non-dict return types from RPC calls (e.g. `ModelNamespace.list_downloaded_models`). The `unit-tests` branch will be reused later when I go to write tests.