### PR TITLE
Docs!

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ As usual, each level logs all levels above it. Depending on the backend, you can
 
 ### Known Limitations
 
-Currently aborting doesn't play very well with synchronous code. Synchronous code might hang and not respect SIGINT (Ctrl+C). Preprocessors are not implemented, nor are diagnostics (and all of the `DiagnosticsNamespace` at that). Please disregard TODOs.
+Currently aborting doesn't play very well with synchronous code. Preprocessors are not implemented, and please disregard TODOs.
+
+Synchronous code is less tested than async code. Synchronous code might hang and not respect SIGINT if calling `result()` on a model load or prediction request. In fact this is a [known issue](https://bugs.python.org/issue35935) with the way `threading.Event.wait()` blocks.
 
 Documentation is also still coming, as are unit tests - maybe there's a typo somewhere in untested code that causes a method to not function properly. This library isn't released yet for a reason.

--- a/README.md
+++ b/README.md
@@ -30,21 +30,23 @@ Discuss all things related to developing with LM Studio in <a href="https://disc
 pip install lmstudio_sdk
 ```
 
-### API Usage
+## Examples
+
+### Loading an LLM and Predicting with It
 
 ```python
 from lmstudio_sdk import LMStudioClient
 
 client = LMStudioClient()
-model = client.llm.unstable_get_any()
+llama3 = client.llm.load("lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF")
 
-for fragment in model.respond([{"role": "user", "content": "Say hello to lmstudio.py!"}], {}):
-    print(fragment, end="")
+for fragment in llama3.respond([{"role": "user", "content": "Say hello to lmstudio.py!"}], {}):
+    print(fragment, end="", flush=True)
 
 client.close()
 ```
 
-Asynchronously:
+Asynchronously, just `await` the constructor and use examples:
 
 ```python
 import asyncio
@@ -52,18 +54,392 @@ from lmstudio_sdk import LMStudioClient
 
 async def main():
     client = await LMStudioClient()
-    model = await client.llm.unstable_get_any()
-    prediction = await model.respond([{"role": "user", "content": "Say hello to lmstudio.py!"}], {})
+    llama3 = await client.llm.load("lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF")
+    prediction = await llama3.respond([{"role": "user", "content": "Say hello to lmstudio.py!"}], {})
 
     async for fragment in prediction:
-        print(fragment, end="")
+        print(fragment, end="", flush=True)
 
     await client.close()
 
 asyncio.run(main())
 ```
 
-TODO: more examples
+> [!NOTE]
+>
+> If you wish to `await` on the result of the prediction rather than streaming it, note that the call to
+> `model.respond()`/`model.complete()` will take **two** `await`s, like so:
+>
+> ```python
+> result = await (await model.respond([{"role": "user", "content": "Say hello to lmstudio.py!"}]))
+> ```
+
+Henceforth all examples will be given synchronously; the asynchronous versions simply have `await` sprinkled in all over.
+
+### Using a Non-Default LM Studio Server Port
+
+This example shows how to connect to LM Studio running on a different port (e.g., 8080).
+
+```python
+from lmstudio_sdk import LMStudioClient
+
+client = new LMStudioClient({"baseUrl": "ws://localhost:8080"})
+
+# client.llm.load(...)
+```
+
+### Giving a Loaded Model a Friendly Name
+
+You can set an identifier for a model when loading it. This identifier can be used to refer to the model later.
+
+```python
+client.llm.load("lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF", {"identifier": "my-model",})
+
+# You can refer to the model later using the identifier
+my_model = client.llm.get("my-model")
+# my_model.complete(...)
+```
+
+### Loading a Model with a Custom Configuration
+
+By default, the load configuration for a model comes from the preset associated with the model (Can be changed on the "My Models" page in LM Studio).
+
+```python
+llama3 = client.llm.load(
+    "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF",
+    {
+        "config": {
+            "context_length": 1024,
+            "gpu_offload": 0.5,  # Offloads 50% of the computation to the GPU
+        },
+    }
+)
+
+# llama3.complete(...)
+```
+
+### Custom Loading Progress
+
+You can track the loading progress of a model by providing an `on_progress` callback.
+
+```python
+llama3 = client.llm.load(
+    "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF",
+    {
+        "verbose": False,  # Disables the default progress logging
+        "on_progress": lambda progress: print(f"Progress: {round(progress * 100, 1)}")
+    }
+)
+```
+
+### Listing all Models that can be Loaded
+
+If you wish to find all models that are available to be loaded, you can use the `list_downloaded_models` method on the `system` object.
+
+```python
+downloaded_models = client.system.list_downloaded_models()
+downloaded_llms = [model for model in downloaded_models if model.type == "llm"]
+
+# Load the first model
+model = client.llm.load(downloaded_llms[0].path)
+# model.complete(...);
+```
+
+### Canceling a Load
+
+You can cancel a load by using an AbortSignal, ported from TypeScript.
+This API will probably change with time. Currently we have one AbortSignal
+class for each of sync and async.
+
+```python
+from lmstudio_sdk import SyncAbortSignal
+
+signal = SyncAbortSignal()
+
+try:
+    llama3 = client.llm.load(
+        "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF",
+        {"signal": signal,}
+    )
+  # llama3.complete(...);
+except Exception as e:
+    logger.error(e)
+
+# Somewhere else in your code:
+controller.abort()
+```
+
+### Unloading a Model
+
+You can unload a model by calling the `unload` method.
+
+```python
+llama3 = client.llm.load("lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF", {"identifier": "my-model"})
+
+# ...Do stuff...
+
+client.llm.unload("my-model")
+```
+
+Note, by default, all models loaded by a client are unloaded when the client disconnects. Therefore, unless you want to precisely control the lifetime of a model, you do not need to unload them manually.
+
+### Using an Already Loaded Model
+
+To look up an already loaded model by its identifier, use the following:
+
+```python
+my_model = client.llm.get({"identifier": "my-model"})
+# Or just
+my_model = client.llm.get("my-model")
+
+# myModel.complete(...)
+```
+
+To look up an already loaded model by its path, use the following:
+
+```python
+# Matches any quantization
+llama3 = client.llm.get({
+    "path": "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF",
+})
+
+# Or if a specific quantization is desired:
+llama3 = client.llm.get({
+    "path": "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF/Meta-Llama-3-8B-Instruct-Q4_K_M.gguf",
+})
+
+# llama3.complete(...)
+```
+
+### Using any Loaded Model
+
+If you do not have a specific model in mind, and just want to use any loaded model, you can use the `unstable_get_any` method:
+
+```python
+any_model = client.llm.unstable_get_any()
+# any_model.complete(...)
+```
+
+### Listing All Loaded Models
+
+To list all loaded models, use the `client.llm.list_loaded` method.
+
+```python
+loaded_models = client.llm.list_loaded()
+
+if loadedModels.length == 0:
+    raise Exception("No models loaded")
+
+# Use the first one
+const first_model = await client.llm.get({
+    "identifier": loaded_models[0]["identifier"],
+})
+# first_model.complete(...);
+```
+
+> Example `list_loaded` Response:
+>
+> ```JSON
+> [
+>   {
+>     "identifier": "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF",
+>     "path": "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF",
+>   },
+>   {
+>     "identifier": "microsoft/Phi-3-mini-4k-instruct-gguf/Phi-3-mini-4k-instruct-q4.gguf",
+>     "path": "microsoft/Phi-3-mini-4k-instruct-gguf/Phi-3-mini-4k-instruct-q4.gguf",
+>   },
+> ]
+> ```
+
+### Text Completion
+
+To perform text completion, use the `complete` method:
+
+```python
+prediction = model.complete("The meaning of life is")
+
+for fragment in prediction:
+    print(fragment, end="", flush=True)
+```
+
+Note that this would be an `async for` in asynchronous code.
+
+By default, the inference parameters in the preset is used for the prediction. You can override them like this:
+
+```python
+const prediction = any_model.complete("Meaning of life is", {
+    "contextOverflowPolicy": "stopAtLimit",
+    "maxPredictedTokens": 100,
+    "stopStrings": ["\n"],
+    "temperature": 0.7,
+})
+
+# ...Do stuff with the prediction...
+```
+
+### Conversation
+
+To perform a conversation, use the `respond` method:
+
+```python
+prediction = any_model.respond([
+    { "role": "system", "content": "Answer the following questions." },
+    { "role": "user", "content": "What is the meaning of life?" },
+])
+
+for fragment in prediction:
+    print(fragment, end="", flush=True)
+```
+
+Similarly, you can override the inference parameters for the conversation (Note the available options are different from text completion):
+
+```python
+prediction = any_model.respond(
+    [
+        { "role": "system", "content": "Answer the following questions." },
+        { "role": "user", "content": "What is the meaning of life?" },
+    ],
+    {
+        "contextOverflowPolicy": "stopAtLimit",
+        "maxPredictedTokens": 100,
+        "stopStrings": ["\n"],
+        "temperature": 0.7,
+    }
+)
+
+# ...Do stuff with the prediction...
+```
+
+> [!IMPORTANT]
+>
+> _Always Provide the Full History/Context_
+>
+> LLMs are _stateless_. They do not remember or retain information from previous inputs. Therefore, when predicting with an LLM, you should always provide the full history/context.
+
+### Getting Prediction Stats
+
+If you wish to get the prediction statistics, you can await on the prediction object to get a `PredictionResult`, through which you can access the stats via the `stats` property.
+
+```python
+prediction = model.complete("The meaning of life is")
+
+stats = prediction.result().stats
+print(stats)
+```
+
+Asynchronously, this looks more like
+
+```python
+prediction = await model.complete("The meaning of life is")
+
+stats = (await prediction).stats
+print(stats)
+```
+
+> [!NOTE]
+>
+> **No Extra Waiting**
+>
+> When you have already consumed the prediction stream, awaiting on the prediction object will not cause any extra waiting, as the result is cached within the prediction object.
+>
+> On the other hand, if you only care about the final result, you don't need to iterate through the stream. Instead, you can await on the prediction object directly to get the final result. An example of what this looks like in JSON is below:
+>
+> ```JSON
+> {
+>   "stopReason": "eosFound",
+>   "tokensPerSecond": 26.644333102146646,
+>   "numGpuLayers": 33,
+>   "timeToFirstTokenSec": 0.146,
+>   "promptTokensCount": 5,
+>   "predictedTokensCount": 694,
+>   "totalTokensCount": 699
+> }
+> ```
+
+### Producing JSON (Structured Output)
+
+LM Studio supports structured prediction, which will force the model to produce content that conforms to a specific structure. To enable structured prediction, you should set the `structured` field. It is available for both `complete` and `respond` methods.
+
+Here is an example of how to use structured prediction:
+
+```python
+prediction = model.complete("Here is a joke in JSON:", {
+    "max_predicted_tokens": 100,
+    "structured": {"type": "json"},
+})
+
+result = prediction.result()
+
+try:
+    # Although the LLM is guaranteed to only produce valid JSON, when it is interrupted, the
+    # partial result might not be. Always check for errors. (See caveats below)
+    parsed = json.loads(result.content)
+    print(parsed)
+except Exception as e:
+    print(f"Error: {e}")
+```
+
+> Example output:
+>
+> ```JSON
+> {
+>  "title": "The Shawshank Redemption",
+>  "genre": [ "drama", "thriller" ],
+>  "release_year": 1994,
+>  "cast": [
+>    { "name": "Tim Robbins", "role": "Andy Dufresne" },
+>    { "name": "Morgan Freeman", "role": "Ellis Boyd" }
+>  ]
+> }
+> ```
+
+Sometimes, any JSON is not enough. You might want to enforce a specific JSON schema. You can do this by providing a JSON schema to the `structured` field. Read more about JSON schema at [json-schema.org](https://json-schema.org/).
+
+```python
+schema = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "age": {"type": "number"},
+    },
+    "required": ["name", "age"],
+}
+prediction = model.complete("...", {
+    "max_predicted_tokens": 100,
+    "structured": {"type": "json", "jsonSchema": schema},
+})
+```
+
+> [!IMPORTANT]
+>
+> **Caveats with Structured Prediction**
+>
+> - Although the model is forced to generate predictions that conform to the specified structure, the prediction may be interrupted (for example, if the user stops the prediction). When that happens, the partial result may not conform to the specified structure. Thus, always check the prediction result before using it, for example, by wrapping the `JSON.parse` inside a try-catch block.
+> - In certain cases, the model may get stuck. For example, when forcing it to generate valid JSON, it may generate a opening brace `{` but never generate a closing brace `}`. In such cases, the prediction will go on forever until the context length is reached, which can take a long time. Therefore, it is recommended to always set a `maxPredictedTokens` limit. This also contributes to the point above.
+
+### Canceling/Aborting a Prediction
+
+A prediction may be canceled by calling the `cancel` method on the prediction object.
+
+```python
+prediction = model.complete("The meaning of life is")
+
+# ...Do stuff...
+
+prediction.cancel()
+```
+
+When a prediction is canceled, the prediction will stop normally but with `stopReason` set to `"userStopped"`. You can detect cancellation like so:
+
+```python
+for fragment in prediction:
+    print(fragment, end="", flush=True)
+
+stats = prediction.result().stats
+if stats.stopReason == "userStopped":
+    print("Prediciton was canceled by the user")
+```
 
 ### Async vs. Sync
 
@@ -82,7 +458,7 @@ but you could also use the output of the first `await` as an async iterable, lik
 ```python
 prediction = await model.respond(["role": "user", "content": "Hello world!"], {})
 async for fragment in prediction:
-    print(fragment, end="")
+    print(fragment, end="", flush=True)
 ```
 
 Pick whichever backend best suits your use case. Incidentally, the asynchronous code runs on `websockets` while the synchronous code runs on `websocket-client` (confusingly imported as `websocket`).

--- a/planning/todos.md
+++ b/planning/todos.md
@@ -3,6 +3,8 @@ TODO: sync code does not respect SIGINT during blocking channel operations like 
 TODO: README + docs
 TODO: preprocessors and generators, full feature parity
 
+TODO TODO: some dataclasses are (or really should be) only ever generated internally, such as PredictionResult. these shoudl not be TypedDicts but rather objects so people can dot access them. figure out which ones these are! eg ModelDescriptor?
+
 TODO TODO TODO: feature parity with all changes brought in by lmstudio.js PR #90 for chat history mostly, but also everything since PR #84 (commit d424b042012699c5d41f9dd3c5b3a5b33677f69d) with which this library is up to date apart from preprocessors
 
 more design questions:

--- a/planning/todos.md
+++ b/planning/todos.md
@@ -3,11 +3,8 @@ TODO: sync code does not respect SIGINT during blocking channel operations like 
 TODO: README + docs
 TODO: preprocessors and generators, full feature parity
 
-TODO: docstrings according to PEP 257
-in particular line length 79 (72 for multiline)
+TODO TODO TODO: feature parity with all changes brought in by lmstudio.js PR #90 for chat history mostly, but also everything since PR #84 (commit d424b042012699c5d41f9dd3c5b3a5b33677f69d) with which this library is up to date apart from preprocessors
 
 more design questions:
 move from option typeddicts to function kwargs? more "Pythonic"?
 pydantic runtime type checking? I guess the TS lib uses Zod
-
-UTD since d424b042012699c5d41f9dd3c5b3a5b33677f69d otherwise

--- a/src/lmstudio_sdk/__init__.py
+++ b/src/lmstudio_sdk/__init__.py
@@ -1,3 +1,19 @@
+"""The Python SDK for the LM Studio WebSocket API.
+
+Use this SDK to interact with the LM Studio server using Python.
+It provides a strict superset of whatever you could do with
+calling the HTTP OpenAI-like API with the OpenAI Python SDK,
+and is intended to be a near drop-in replacement.
+
+It also provides feature parity with the TypeScript SDK, so any
+code you have in TypeScript can be translated almost directly
+to Python.
+
+Please refer to the README on the official project GitHub
+for examples and documentation.
+"""
+# TODO: make a better and longer docstring
+
 from .backend import (
     AsyncLMStudioClient,
     AsyncOngoingPrediction,

--- a/src/lmstudio_sdk/backend/__init__.py
+++ b/src/lmstudio_sdk/backend/__init__.py
@@ -1,4 +1,20 @@
-# TODO: docstring
+"""Backend and communication classes for the LM Studio SDK.
+
+Classes:
+    AsyncLMStudioClient: asynchronous client using asyncio.
+    SyncLMStudioClient: synchronous client using blocking calls.
+    AsyncOngoingPrediction: ongoing prediction for asynchronous clients.
+    SyncOngoingPrediction: ongoing prediction for synchronous clients.
+    DynamicHandle: base class for dynamic handles.
+    EmbeddingDynamicHandle: dynamic handle for embedding functions.
+    EmbeddingSpecificModel: specific model for embedding functions.
+    LLMDynamicHandle: dynamic handle for LLM functions.
+    LLMSpecificModel: specific model for LLM functions.
+    DiagnosticsNamespace: method namespace for server diagnostics.
+    EmbeddingNamespace: method namespace for embedding functions.
+    LLMNamespace: method namespace for LLM functions.
+    ModelNamespace: method namespace for model functions.
+"""
 
 from .client import AsyncLMStudioClient, LMStudioClient, SyncLMStudioClient
 from .communications import (

--- a/src/lmstudio_sdk/backend/client/AsyncLMStudioClient.py
+++ b/src/lmstudio_sdk/backend/client/AsyncLMStudioClient.py
@@ -3,6 +3,8 @@ import http.client
 import json
 import urllib.error
 from typing import Optional
+from typing_extensions import override
+
 
 import lmstudio_sdk.utils as utils
 
@@ -13,7 +15,47 @@ logger = utils.get_logger(__name__)
 
 
 class AsyncLMStudioClient(LMStudioClient):
-    # TODO: docstring
+    """Asynchronous client for the LM Studio server.
+
+    A more faithful port of the TypeScript SDK: if you have code in
+    TypeScript, it will translate almost directly to this client.
+    If you are not familiar with asyncio or are adapting an application
+    that used the OpenAI Python SDK, you may want to use the synchronous
+    client instead.
+
+    Do not construct this directly unless you know what you are doing.
+    Instead, use the `LMStudioClient` factory function: it will return
+    an instance of this class if `await`ed.
+
+    Methods are dot accessed through the four namespaces:
+    llm, embedding, system, and diagnostics. For example:
+
+    ```python
+    llm_client = await LMStudioClient()
+
+    print(await llm_client.system.list_downloaded_models())
+
+    model = await llm_client.llm.get("qwen2")
+    result = await model.respond(
+        [{"role": "user", "content": "Tell me a long story."}],
+        {}
+    )
+
+    async for completion in result:
+        print(completion)
+    ```
+
+    Attributes:
+        client_identifier: Unique identifier for the client.
+        base_url: Base URL for the LM Studio server.
+        llm: Method namespace for interacting with LLM models.
+        embedding: Method namespace for interacting with embedding models.
+        system: Method namespace for LM Studio system functions.
+        diagnostics: Method namespace for server diagnostics.
+    """
+
+    # TODO wait, why is this async? It's not doing anything async
+    @override
     async def _is_localhost_with_given_port_lmstudio_server(
         self, port: int
     ) -> int:
@@ -37,6 +79,7 @@ class AsyncLMStudioClient(LMStudioClient):
         finally:
             conn.close()
 
+    @override
     async def _guess_base_url(self) -> str:
         try:
             port = await asyncio.wait_for(
@@ -72,6 +115,7 @@ class AsyncLMStudioClient(LMStudioClient):
     ):
         super().__init__(base_url, client_identifier, client_passkey)
 
+    @override
     async def connect(self):
         if self.base_url is None:
             logger.warning("base_url is None. Attempting to guess base_url.")
@@ -107,6 +151,7 @@ class AsyncLMStudioClient(LMStudioClient):
 
         return self
 
+    @override
     async def close(self):
         logger.info(
             "Closing connection to LM Studio server at %s...", self.base_url

--- a/src/lmstudio_sdk/backend/client/LMStudioClient.py
+++ b/src/lmstudio_sdk/backend/client/LMStudioClient.py
@@ -12,12 +12,22 @@ logger = utils.get_logger(__name__)
 
 class LMStudioClient(ABC):
     client_identifier: str
+    """Unique identifier for the client."""
+
     base_url: Optional[str]
+    """Base URL for the LM Studio server."""
 
     llm: ns.LLMNamespace = None
+    """Method namespace for interacting with LLM models."""
+
     embedding: ns.EmbeddingNamespace = None
+    """Method namespace for interacting with embedding models."""
+
     system: ns.SystemNamespace = None
+    """Method namespace for LM Studio system functions."""
+
     diagnostics: ns.DiagnosticsNamespace = None
+    """Method namespace for server diagnostics."""
 
     def _validate_base_url_or_throw(self, base_url):
         error_msg = None
@@ -74,13 +84,28 @@ class LMStudioClient(ABC):
 
     @abstractmethod
     def connect(self):
+        """Connect to the LM Studio server on all ports.
+
+        Raises:
+            ValueError: If the connection cannot be established.
+        """
         pass
 
     @abstractmethod
     def close(self):
+        """Close the connection to the LM Studio server on all ports."""
         pass
 
     def _create_ports(self, is_async: bool):
+        """Create ports for the client.
+
+        Args:
+            is_async (bool): Whether to create async or sync ports.
+
+        Raises:
+            ValueError: If the base_url, client_identifier,
+                or client_passkey is None.
+        """
         error_msg = None
         if self.base_url is None:
             error_msg = "Failed to create ports: base_url is None"

--- a/src/lmstudio_sdk/backend/client/LMStudioClientFactory.py
+++ b/src/lmstudio_sdk/backend/client/LMStudioClientFactory.py
@@ -5,15 +5,28 @@ from .AsyncLMStudioClient import AsyncLMStudioClient
 from .SyncLMStudioClient import SyncLMStudioClient
 
 
+# TODO: would be nice to use a context manager so close() is handled automatically
 def LMStudioClient(
     base_url: Optional[str] = None,
     client_identifier: Optional[str] = None,
     client_passkey: Optional[str] = None,
 ) -> SyncLMStudioClient | Coroutine[Any, Any, AsyncLMStudioClient]:
-    """Constructs an instance of either `AsyncLMStudioClient` or `SyncLMStudioClient`.
+    """Constructs an LM Studio client connected to the server.
 
-    `await LMStudioClient()` will return an instance of `AsyncLMStudioClient`.
-    `LMStudioClient()` will return an instance of `SyncLMStudioClient`.
+    Args:
+    - base_url: The URL of the LM Studio server.
+    - client_identifier: The unique identifier for the client.
+    - client_passkey: The passkey for the client.
+
+    If these are not provided, the client will attempt to guess the base URL,
+    and generate random values for the client identifier and passkey.
+
+    Returns:
+    - An instance of `AsyncLMStudioClient` or `SyncLMStudioClient`
+      connected to the server. `awaiting` this function will return the former.
+
+    Raises:
+    - ValueError: If a connection cannot be established.
     """
     is_async = (
         inspect.currentframe().f_back.f_code.co_flags & inspect.CO_COROUTINE

--- a/src/lmstudio_sdk/backend/client/SyncLMStudioClient.py
+++ b/src/lmstudio_sdk/backend/client/SyncLMStudioClient.py
@@ -2,6 +2,7 @@ import json
 import urllib.error
 import urllib.request
 from typing import Optional
+from typing_extensions import override
 
 import lmstudio_sdk.utils as utils
 
@@ -12,7 +13,45 @@ logger = utils.get_logger(__name__)
 
 
 class SyncLMStudioClient(LMStudioClient):
-    # TODO: docstring
+    """Synchronous client for the LM Studio server.
+
+    Intended to be a drop-in replacement for the OpenAI Python SDK.
+    If you are porting code from TypeScript, are building an application
+    with asyncio, or desire greater control over the event loop, consider
+    using the asynchronous client instead.
+
+    Do not construct this directly unless you know what you are doing.
+    Instead, use the `LMStudioClient` factory function: it will return
+    an instance of this class if called normally.
+
+    Methods are dot accessed through the four namespaces:
+    llm, embedding, system, and diagnostics. For example:
+
+    ```python
+    llm_client = LMStudioClient()
+
+    print(llm_client.system.list_downloaded_models())
+
+    model = llm_client.llm.get("qwen2")
+    result = model.respond(
+        [{"role": "user", "content": "Tell me a long story."}],
+        {}
+    )
+
+    for completion in result:
+        print(completion)
+    ```
+
+    Attributes:
+        client_identifier: Unique identifier for the client.
+        base_url: Base URL for the LM Studio server.
+        llm: Method namespace for interacting with LLM models.
+        embedding: Method namespace for interacting with embedding models.
+        system: Method namespace for LM Studio system functions.
+        diagnostics: Method namespace for server diagnostics.
+    """
+
+    @override
     def _is_localhost_with_given_port_lmstudio_server(self, port: int) -> int:
         url = f"http://127.0.0.1:{port}/lmstudio-greeting"
         try:
@@ -29,6 +68,7 @@ class SyncLMStudioClient(LMStudioClient):
         except (urllib.error.URLError, ValueError) as e:
             raise ValueError("Failed to connect to the server: %s", str(e))
 
+    @override
     def _guess_base_url(self) -> str:
         for port in utils.lms_default_ports:
             try:
@@ -64,6 +104,7 @@ class SyncLMStudioClient(LMStudioClient):
     ):
         super().__init__(base_url, client_identifier, client_passkey)
 
+    @override
     def connect(self):
         if self.base_url is None:
             logger.warning("base_url is None. Attempting to guess base_url.")
@@ -103,6 +144,7 @@ class SyncLMStudioClient(LMStudioClient):
 
         return self
 
+    @override
     def close(self):
         logger.info(
             "Closing connection to LM Studio server at %s...", self.base_url

--- a/src/lmstudio_sdk/backend/client/__init__.py
+++ b/src/lmstudio_sdk/backend/client/__init__.py
@@ -1,7 +1,18 @@
+"""User clients providing an interface to the LM Studio server.
+
+Classes:
+    AsyncLMStudioClient: asynchronous client using asyncio.
+    SyncLMStudioClient: synchronous client using blocking calls.
+
+Methods:
+    LMStudioClient: creates either client based on the context.
+
+Each client is meant to mirror the TypeScript SDK as closely as possible.
+"""
+
 from .AsyncLMStudioClient import AsyncLMStudioClient
 from .LMStudioClientFactory import LMStudioClient
 from .SyncLMStudioClient import SyncLMStudioClient
-# TODO: docstring
 
 __all__ = [
     "AsyncLMStudioClient",

--- a/src/lmstudio_sdk/backend/communications/__init__.py
+++ b/src/lmstudio_sdk/backend/communications/__init__.py
@@ -1,7 +1,12 @@
 # pylance: disable=unused-imports
 # flake8: noqa: f401
 # ruff: noqa: F401
-# TODO: docstring
+"""Backend communications classes.
+
+Only ongoing prediction classes are exported as
+part of the public API. See the `ongoing_prediction`
+submodule for more information.
+"""
 
 from ._client_port import AsyncClientPort, BaseClientPort, SyncClientPort
 from .ongoing_prediction import (

--- a/src/lmstudio_sdk/backend/communications/_client_port/BaseClientPort.py
+++ b/src/lmstudio_sdk/backend/communications/_client_port/BaseClientPort.py
@@ -10,6 +10,38 @@ logger = utils.get_logger(__name__)
 
 
 class BaseClientPort(ABC):
+    """Abstract class describing a client port for LM Studio communication.
+
+    Not part of the public API, but worth documenting. This class outlines
+    the internal API for communication with the server, since we use two
+    different backends: `websocket-client` for synchronous communication
+    and `websockets` for asynchronous communication.
+
+    This class handles common functionality (e.g. handling call IDs)
+    and defines the `create_channel`, `send_channel_message`,
+    and `call_rpc` methods that should be used by other code
+    to interact with the server.
+
+    The current communications framework uses `postprocess` callbacks
+    to process responses from the server, which is a bit of a hack
+    to allow the same public API methods to function both synchronously
+    and asynchronously. This is not a very good design pattern!
+
+    It works fine for e.g. RPC calls where all we need to do is
+    extract a particular field from the response, but for channel methods
+    where we need to tie abort callbacks to the channel ID (which is not
+    determined until after the call is made), it's a bit of a mess.
+
+    Attributes:
+        uri: Full URI for the client connection.
+        endpoint: Endpoint for the client, e.g. "llm".
+        identifier: Unique identifier for the client.
+        _passkey: Passkey for the client.
+        _websocket: WebSocket instance (will differ by backend).
+        channel_handlers: Handler callbacks for channel messages.
+        rpc_handlers: Handler callbacks for RPC calls.
+    """
+
     _auth_version = 1
     __next_channel_id = 0
     __next_rpc_call_id = 0
@@ -27,10 +59,12 @@ class BaseClientPort(ABC):
 
     @abstractmethod
     def connect(self):
+        """Connect to the server on all ports."""
         pass
 
     @abstractmethod
     def close(self):
+        """Close the connection to the server on all ports."""
         pass
 
     @abstractmethod
@@ -40,6 +74,24 @@ class BaseClientPort(ABC):
         extra: Optional[dict] = None,
         postprocess: Optional[Callable[[dict], Any]] = None,
     ):
+        """Send a JSON message to the server over the backend.
+
+        Should be the only method that directly interacts with the
+        backend's WebSocket implementation.
+
+        Args:
+            payload: JSON payload to send.
+            extra: Arguments to `postprocess`. Useful for e.g. passing
+                channel IDs to abort callbacks.
+            postprocess: Callback to process the response.
+                Will be called on the response from the server,
+                and should return the desired result. Should be
+                propagated all the way from the public API method
+                at the top of the call stack.
+
+        Returns:
+            The result of the `postprocess` callback on `extra`.
+        """
         pass
 
     @abstractmethod
@@ -51,14 +103,32 @@ class BaseClientPort(ABC):
         postprocess: Callable[[dict], Any],
         extra: Optional[dict],
     ):
+        """Backend: send an RPC to the server.
+
+        Backend implementation of `call_rpc`, which should be used in the
+        internal API, so must be implemented on a per-backend basis.
+
+        Args:
+            payload: JSON payload to send.
+            complete: Event to set when the RPC completes.
+            result: Dictionary to store the result of the RPC.
+            postprocess: Callback to process the response. Not to be confused
+                with the `postprocess` argument to `_send_payload`.
+            extra: Extra data to `postprocess`.
+
+        Returns:
+            The result of the RPC, after postprocessing.
+        """
         pass
 
     @abstractmethod
     def _rpc_complete_event(self) -> threading.Event | asyncio.Event:
+        """Dependency inject a complete event."""
         pass
 
     @abstractmethod
     def _promise_event(self) -> asyncio.Future | utils.PseudoFuture:
+        """Dependency inject a Future-like."""
         pass
 
     @classmethod
@@ -75,6 +145,43 @@ class BaseClientPort(ABC):
             cls.__next_rpc_call_id += 1
         return call_id
 
+    def _handle_data(self, data: dict):
+        """Handle an incoming packet from the server.
+
+        Used in message receipt loops to process incoming messages.
+
+        Args:
+            data: JSON data from the server.
+        """
+        data_type = data.get("type", None)
+        if data_type is None:
+            return
+
+        # channel endpoints
+        if data_type == "channelSend":
+            channel_id = data.get("channelId")
+            if channel_id in self.channel_handlers:
+                message_content = data.get("message", data)
+                if message_content.get("type", None) == "log":
+                    message_content = message_content.get("log")
+                self.channel_handlers[channel_id](message_content)
+        elif data_type == "channelClose":
+            channel_id = data.get("channelId")
+            if channel_id in self.channel_handlers:
+                del self.channel_handlers[channel_id]
+        elif data_type == "channelError":
+            channel_id = data.get("channelId")
+            if channel_id in self.channel_handlers:
+                self.channel_handlers[channel_id](data)
+                del self.channel_handlers[channel_id]
+
+        # RPC endpoints
+        elif data_type == "rpcResult" or data_type == "rpcError":
+            call_id = data.get("callId", -1)
+            if call_id in self.rpc_handlers:
+                self.rpc_handlers[call_id](data)
+                del self.rpc_handlers[call_id]
+
     def is_async(self):
         return asyncio.iscoroutinefunction(self._send_payload)
 
@@ -85,7 +192,25 @@ class BaseClientPort(ABC):
         handler: Callable,
         postprocess: Callable[[dict], Any],
         extra: Optional[dict] = None,
-    ) -> int:
+    ):
+        """Create a channel to the server.
+
+        This returns as soon as the channel has been established
+        and postprocessing completed. In practice this means that
+        `postprocess` should do no more than e.g. register
+        abort callbacks.
+
+        Args:
+            endpoint: Endpoint to create the channel to.
+            creation_parameter: Parameters to pass to the channel creation.
+            handler: Callback to handle incoming messages on the channel.
+            postprocess: Callback to process the response.
+            extra: Extra data to pass to `postprocess`.
+
+        Returns:
+            The result of the `postprocess` callback on the channel ID
+            and `extra`, after sending the channel creation packet.
+        """
         assert self._websocket is not None
         channel_id = self.__get_next_channel_id()
         payload = {
@@ -111,6 +236,15 @@ class BaseClientPort(ABC):
         )
 
     def send_channel_message(self, channel_id: int, message: dict):
+        """Send a message on a channel.
+
+        In practice this is just for cancelling channel operations
+        like model loading and inference.
+
+        Args:
+            channel_id: ID of the channel to send the message on.
+            message: Message to send on the channel.
+        """
         assert self._websocket is not None
         payload = {
             "type": "channelSend",
@@ -132,6 +266,23 @@ class BaseClientPort(ABC):
         postprocess: Callable[[dict], Any],
         extra: Optional[dict] = None,
     ):
+        """Send an RPC to the server.
+
+        Will block until the RPC completes, then return the desired
+        result as specified by calling `postprocess` on the response.
+
+        This should actually not block in the async case, but it does:
+        needs to be fixed.
+
+        Args:
+            endpoint: Endpoint to send the RPC to.
+            parameter: Parameters to pass to the RPC.
+            postprocess: Callback to process the response.
+            extra: Extra data to pass to `postprocess`.
+
+        Returns:
+            The result of the `postprocess` callback on the RPC result.
+        """
         assert self._websocket is not None
         result = {}
 

--- a/src/lmstudio_sdk/backend/communications/ongoing_prediction/BaseOngoingPrediction.py
+++ b/src/lmstudio_sdk/backend/communications/ongoing_prediction/BaseOngoingPrediction.py
@@ -8,9 +8,19 @@ TFinal = TypeVar("TFinal")
 
 
 class BaseStreamableIterator(Generic[TFragment, TFinal], ABC):
-    def __init__(self):
+    """An abstract streamable iterator."""
+
+    def __init__(self, on_cancel: Callable[[], None]):
         self.status: str = "pending"
         self.buffer: List[TFragment] = []
+
+        # technically these are ongoing prediction specific,
+        # but the inheritance hierarchy makes it easier to put them here
+        self._on_cancel = on_cancel
+        self._stats: Optional[dc.LLMPredictionStats] = None
+        self._model_info: Optional[dc.ModelDescriptor] = None
+        self._load_model_config: Optional[dc.KVConfig] = None
+        self._prediction_config: Optional[dc.KVConfig] = None
 
     @abstractmethod
     def collect(self, fragments: List[str]) -> dc.PredictionResult:
@@ -30,9 +40,43 @@ class BaseStreamableIterator(Generic[TFragment, TFinal], ABC):
 
 
 class BaseOngoingPrediction(BaseStreamableIterator[TFragment, TFinal], ABC):
-    @abstractmethod
-    def create(on_cancel: Callable[[], None]) -> TFinal:
-        pass
+    """An abstract ongoing prediction."""
+
+    @classmethod
+    def create(
+        cls,
+        on_cancel: Callable[[], None],
+    ) -> tuple[
+        "BaseOngoingPrediction",
+        Callable[..., None],
+        Callable[..., None],
+        Callable[[str], None],
+    ]:
+        """Create a new ongoing prediction instance.
+
+        Registers the finished, failed, and push callbacks
+        with the ongoing prediction instance as well."""
+        ongoing_prediction = cls(on_cancel)
+
+        def finished(
+            stats: dc.LLMPredictionStats,
+            model_info: dc.ModelDescriptor,
+            load_model_config: dc.KVConfig,
+            prediction_config: dc.KVConfig,
+        ) -> None:
+            ongoing_prediction._stats = stats
+            ongoing_prediction._model_info = model_info
+            ongoing_prediction._load_model_config = load_model_config
+            ongoing_prediction._prediction_config = prediction_config
+            ongoing_prediction.finished()
+
+        def failed(error: Any = None) -> None:
+            ongoing_prediction.finished(error)
+
+        def push(fragment: str) -> None:
+            ongoing_prediction.push(fragment)
+
+        return ongoing_prediction, finished, failed, push
 
     @abstractmethod
     def result(self) -> TFinal:

--- a/src/lmstudio_sdk/backend/communications/ongoing_prediction/BaseOngoingPrediction.py
+++ b/src/lmstudio_sdk/backend/communications/ongoing_prediction/BaseOngoingPrediction.py
@@ -17,10 +17,6 @@ class BaseStreamableIterator(Generic[TFragment, TFinal], ABC):
         # technically these are ongoing prediction specific,
         # but the inheritance hierarchy makes it easier to put them here
         self._on_cancel = on_cancel
-        self._stats: Optional[dc.LLMPredictionStats] = None
-        self._model_info: Optional[dc.ModelDescriptor] = None
-        self._load_model_config: Optional[dc.KVConfig] = None
-        self._prediction_config: Optional[dc.KVConfig] = None
 
     @abstractmethod
     def collect(self, fragments: List[str]) -> dc.PredictionResult:
@@ -41,6 +37,11 @@ class BaseStreamableIterator(Generic[TFragment, TFinal], ABC):
 
 class BaseOngoingPrediction(BaseStreamableIterator[TFragment, TFinal], ABC):
     """An abstract ongoing prediction."""
+
+    _stats: Optional[dc.LLMPredictionStats] = None
+    _model_info: Optional[dc.ModelDescriptor] = None
+    _load_model_config: Optional[dc.KVConfig] = None
+    _prediction_config: Optional[dc.KVConfig] = None
 
     @classmethod
     def create(

--- a/src/lmstudio_sdk/backend/communications/ongoing_prediction/__init__.py
+++ b/src/lmstudio_sdk/backend/communications/ongoing_prediction/__init__.py
@@ -1,8 +1,20 @@
 # pylance: disable=unused-imports
 # flake8: noqa: f401
 # ruff: noqa: F401
+"""Classes representing ongoing prediction processes.
 
-# TODO: docstring
+Classes:
+    AsyncOngoingPrediction: ongoing prediction using asyncio.
+    SyncOngoingPrediction: ongoing prediction using blocking calls.
+
+Each class is meant to mirror the TypeScript SDK as closely as possible.
+Both are iterables: AsyncOngoingPrediction with `async for`, and
+SyncOngoingPrediction with `for`. They yield fragments of the prediction
+as they become available.
+
+Alternatively, `result()` can be called to get the entire prediction
+as a single string.
+"""
 
 from .AsyncOngoingPrediction import AsyncOngoingPrediction
 from .BaseOngoingPrediction import BaseOngoingPrediction

--- a/src/lmstudio_sdk/backend/handles/DynamicHandle.py
+++ b/src/lmstudio_sdk/backend/handles/DynamicHandle.py
@@ -6,18 +6,10 @@ import lmstudio_sdk.backend.communications as comms
 
 
 class DynamicHandle:
-    # TODO: docstrings
     """Represents a set of requirements for a model.
 
     It is not tied to a specific model, but rather
     to a set of requirements that a model must satisfy.
-
-    For example, if you got the model via
-    `client.llm.get("my-identifier")`,
-    you will get a `LLMModel` for the model with the identifier
-    `my-identifier`. If the model is unloaded, and another model
-    is loaded with the same identifier,
-    using the same `LLMModel` will use the new model.
     """
 
     _port: comms.BaseClientPort
@@ -32,12 +24,13 @@ class DynamicHandle:
     def get_model_info(
         self,
     ) -> utils.LiteralOrCoroutine[Optional[dc.ModelDescriptor]]:
-        """Gets the information of the currently associated model.
+        """Get the information of the currently associated model.
 
-        If no model is currently associated, this will return `None`.
+        As models are loaded/unloaded, the model associated
+        with this method may change at any moment.
 
-        Note: As models are loaded/unloaded, the model associated
-        with this `LLMModel` may change at any moment.
+        Returns:
+            The model descriptor if the model is loaded, else `None`.
         """
         return self._port.call_rpc(
             "getModelInfo",
@@ -48,6 +41,13 @@ class DynamicHandle:
     def get_load_config(
         self, postprocess: Callable[[dict], Any] = lambda x: x
     ) -> utils.LiteralOrCoroutine[dc.KVConfig]:
+        """Get the load configuration of the currently associated model.
+
+        Most often used under the hood to get a particular load config value.
+
+        Returns:
+            The load configuration of the model.
+        """
         return self._port.call_rpc(
             "getLoadConfig", {"specifier": self._specifier}, postprocess
         )

--- a/src/lmstudio_sdk/backend/handles/EmbeddingDynamicHandle.py
+++ b/src/lmstudio_sdk/backend/handles/EmbeddingDynamicHandle.py
@@ -10,28 +10,29 @@ logger = utils.get_logger(__name__)
 
 
 class EmbeddingDynamicHandle(DynamicHandle):
-    # TODO: docstrings
     """Represents a set of requirements for a model.
 
     It is not tied to a specific model, but rather
     to a set of requirements that a model must satisfy.
 
-    For example, if you got the model via `client.embedding.get("my-identifier")`, you will get a
-    `EmbeddingModel` for the model with the identifier `my-identifier`. If the model is unloaded, and
-    another model is loaded with the same identifier, using the same `EmbeddingModel` will use the
-    new model.
-
-    :public:
+    For example, if you got the model via `client.embedding.get({
+    "identifier": "my-identifier"})`, you will get an
+    `EmbeddingSpecificModel` for the model with the identifier
+    `my-identifier`. If the model is unloaded, and another model
+    is loaded with the same identifier,
+    using the same `EmbeddingSpecificModel` will use the new model.
     """
 
     def embed_string(
         self, input_string: str
     ) -> utils.LiteralOrCoroutine[dict[str, List[float]]]:
-        """
-        Embed a string into a vector representation.
+        """Embed a string into a vector representation.
 
-        :param input_string: The string to embed.
-        :return: A dictionary containing the embedding as a list of floats.
+        Args:
+            input_string: The string to embed.
+
+        Returns:
+            A dictionary containing the embedding as a list of floats.
         """
         utils._assert(
             isinstance(input_string, str),
@@ -46,10 +47,10 @@ class EmbeddingDynamicHandle(DynamicHandle):
         )
 
     def unstable_get_context_length(self) -> utils.LiteralOrCoroutine[int]:
-        """
-        Get the context length of the model.
+        """Get the context length of the model.
 
-        :return: The context length as an integer.
+        Returns:
+            The context length as an integer.
         """
         return self._port.call_rpc(
             "getLoadConfig",
@@ -61,10 +62,10 @@ class EmbeddingDynamicHandle(DynamicHandle):
         )
 
     def unstable_get_eval_batch_size(self) -> utils.LiteralOrCoroutine[int]:
-        """
-        Get the evaluation batch size of the model.
+        """Get the evaluation batch size of the model.
 
-        :return: The evaluation batch size as an integer.
+        Returns:
+            The evaluation batch size as an integer.
         """
         return self.get_load_config(
             lambda x: dc.find_key_in_kv_config(
@@ -76,11 +77,16 @@ class EmbeddingDynamicHandle(DynamicHandle):
     def unstable_tokenize(
         self, input_string: str
     ) -> utils.LiteralOrCoroutine[List[int]]:
-        """
-        Tokenize the input string.
+        """Tokenize the input string.
 
-        :param input_string: The string to tokenize.
-        :return: A list of integers representing the tokenized string.
+        Always tokenize using the exact model you will be using
+        for prediction, as tokenization can vary between models.
+
+        Args:
+            input_string: The string to tokenize.
+
+        Returns:
+            A list of integers representing the tokenized string.
         """
         utils._assert(
             isinstance(input_string, str),

--- a/src/lmstudio_sdk/backend/handles/LLMDynamicHandle.py
+++ b/src/lmstudio_sdk/backend/handles/LLMDynamicHandle.py
@@ -11,6 +11,7 @@ logger = utils.get_logger(__name__)
 
 
 def predict_internal_process_result(extra):
+    """Abort handler callback for predict_internal."""
     original_extra = extra.get("extra")
     cancel_event = original_extra.get("cancel_event")
     cancel_send = original_extra.get("cancel_send")
@@ -22,17 +23,17 @@ def predict_internal_process_result(extra):
 
 
 class LLMDynamicHandle(DynamicHandle):
-    # TODO: docstrings
-    """
-    This represents a set of requirements for a model. It is not tied to a specific model, but rather
+    """Represents a set of requirements for a model.
+
+    It is not tied to a specific model, but rather
     to a set of requirements that a model must satisfy.
 
-    For example, if you got the model via `client.llm.get("my-identifier")`, you will get a
-    `LLMModel` for the model with the identifier `my-identifier`. If the model is unloaded, and
-    another model is loaded with the same identifier, using the same `LLMModel` will use the new
-    model.
-
-    :public:
+    For example, if you got the model via `client.llm.get({
+    "identifier": "my-identifier"})`, you will get a
+    `LLMSpecificModel` for the model with the identifier
+    `my-identifier`. If the model is unloaded, and another model
+    is loaded with the same identifier,
+    using the same `LLMSpecificModel` will use the new model.
     """
 
     _internal_kv_config_stack = dc.KVConfigStack(layers=[])
@@ -40,6 +41,7 @@ class LLMDynamicHandle(DynamicHandle):
     def __prediction_config_to_kv_config(
         self, prediction_config: Optional[dc.LLMPredictionConfig]
     ) -> dc.KVConfig:
+        """Converts a prediction config to a KVConfig."""
         fields = []
         if prediction_config is not None:
             for default_key in [
@@ -164,10 +166,37 @@ class LLMDynamicHandle(DynamicHandle):
         comms.SyncOngoingPrediction
         | Coroutine[Any, Any, comms.AsyncOngoingPrediction]
     ):
+        """Internal method for a prediction process.
+
+        Should never be called externally! This is not part of the public API.
+
+        Args:
+            model_specifier: The model specifier of the model
+                to use for prediction.
+            context: The context to use for prediction. Will usually be
+                formatted by a public API method.
+            prediction_config_stack: The prediction config stack.
+            cancel_event: A pending prediction cancel event, to be registered.
+                Will be added to the returned ongoing prediction
+                and triggerable using `.cancel()`.
+            extra_opts: Extra prediction options not in the config stack.
+            on_fragment: Callback on receiving a response fragment.
+            on_finished: Callback on response completion.
+            on_error: Callback on channel error.
+            postprocess: The postprocess handler. See `BaseClientPort`.
+            extra: Extra data. See `BaseClientPort`.
+
+        Returns:
+            The ongoing prediction invoked on the server.
+
+        Raises:
+            ChannelError: if an error occurs in the channel during prediction.
+        """
         finished = self._port._rpc_complete_event()
         is_first_token = True
 
         def handle_fragments(message: dict):
+            """Handle incoming messages related to this prediction."""
             message_type = message.get("type", "")
             if message_type == "fragment":
                 on_fragment(message.get("fragment", ""))
@@ -210,6 +239,7 @@ class LLMDynamicHandle(DynamicHandle):
                 on_error(utils.ChannelError(message.get("error").get("title")))
 
         def cancel_send(channel_id):
+            """Send a cancel message to the server."""
             logger.info(
                 "Attempting to send cancel message to channel %d.", channel_id
             )
@@ -240,7 +270,7 @@ class LLMDynamicHandle(DynamicHandle):
     def complete(
         self,
         prompt: dc.LLMCompletionContextInput,
-        opts: Optional[dc.LLMPredictionOpts],
+        opts: Optional[dc.LLMPredictionOpts] = None,
     ) -> (
         comms.SyncOngoingPrediction
         | Coroutine[Any, Any, comms.AsyncOngoingPrediction]
@@ -248,47 +278,56 @@ class LLMDynamicHandle(DynamicHandle):
         """
         Use the loaded model to predict text.
 
-        This method returns an {@link SyncOngoingPrediction} object. An ongoing prediction can be used as a
-        promise (if you only care about the final result) or as an async iterable (if you want to
-        stream the results as they are being generated).
+        This method returns an OngoingPrediction object,
+        sync or async depending on the client context.
+        It can be used as a "promise" if you only care about the final result
+        or as an (async) iterable if you want to stream the results as they
+        are generated.
 
-        Example usage as a promise (Resolves to a {@link PredictionResult}):
+        Example synchronous usage as a promise (Resolves to a `PredictionResult`):
 
-        ```typescript
-        const result = await model.complete("When will The Winds of Winter be released?");
-        console.log(result.content);
+        ```python
+        result = model.complete("When will The Winds of Winter be released?")
+        print(result.result().content)
         ```
 
-        Or
+        And asynchronous:
 
-        ```typescript
-        model.complete("When will The Winds of Winter be released?")
-         .then(result => console.log(result.content))
-         .catch(error => console.error(error));
+        ```python
+        result = await model.complete("When will The Winds of Winter be released?")
+        print((await result).content)
         ```
 
-        Example usage as an async iterable (streaming):
+        Example usage as sync iterable (streaming):
 
-        ```typescript
-        for await (const fragment of model.complete("When will The Winds of Winter be released?")) {
-          process.stdout.write(fragment);
-        }
+        ```python
+        completion = model.complete("When will The Winds of Winter be released?")
+
+        for (fragment of completion):
+            print(fragment, end='')
         ```
 
-        If you wish to stream the result, but also getting the final prediction results (for example,
-        you wish to get the prediction stats), you can use the following pattern:
+        And asynchronous:
 
-        ```typescript
-        const prediction = model.complete("When will The Winds of Winter be released?");
-        for await (const fragment of prediction) {
-          process.stdout.write(fragment);
-        }
-        const result = await prediction;
-        console.log(result.stats);
+        ```python
+        completion = await model.complete("When will The Winds of Winter be released?")
+        async for fragment in completion:
+            print(fragment, end='')
         ```
 
-        :param prompt: The prompt to use for prediction.
-        :param opts: Options for the prediction.
+        The result is already available in the internal buffer after streaming,
+        so calling `result()` (e.g. to get prediction stats) will not block.
+
+        The OngoingPrediction object can also be used to cancel the prediction
+        using `cancel()`.
+
+        Args:
+            prompt: The prompt to use for generating a completion.
+            opts: Options for the prediction, if any. Defaults to using the
+                options set in the LM Studio server.
+
+        Returns:
+            An OngoingPrediction object representing the prediction process.
         """
         utils._assert(
             isinstance(prompt, str),
@@ -367,51 +406,75 @@ class LLMDynamicHandle(DynamicHandle):
         """
         Use the loaded model to generate a response based on the given history.
 
-        This method returns an {@link SyncOngoingPrediction} object. An ongoing prediction can be used as a
-        promise (if you only care about the final result) or as an async iterable (if you want to
-        stream the results as they are being generated).
+        This method returns an OngoingPrediction object,
+        sync or async depending on the client context.
+        It can be used as a "promise" if you only care about the final result
+        or as an (async) iterable if you want to stream the results as they
+        are generated.
 
-        Example usage as a promise (Resolves to a {@link PredictionResult}):
+        If you are tracking a conversation, you should modify the chat `history`
+        within your application; whatever is sent to this method will be used
+        in the prediction! This method does not store any conversation state.
+        For instance, if you are creating a chat UI, simply modifying an entry
+        in the `history` list will update the conversation as if the user
+        edited a message.
 
-        ```typescript
-        const history = [{ role: 'user', content: "When will The Winds of Winter be released?" }];
-        const result = await model.respond(history);
-        console.log(result.content);
+        Example synchronous usage as a promise (Resolves to a `PredictionResult`):
+
+        ```python
+        result = model.respond([{
+            "role": "user",
+            "content": "When will The Winds of Winter be released?"
+        }])
+        print(result.result().content)
         ```
 
-        Or
+        And asynchronous:
 
-        ```typescript
-        const history = [{ role: 'user', content: "When will The Winds of Winter be released?" }];
-        model.respond(history)
-         .then(result => console.log(result.content))
-         .catch(error => console.error(error));
+        ```python
+        result = await model.respond([{
+            "role": "user",
+            "content": "When will The Winds of Winter be released?"
+        }])
+        print((await result).content)
         ```
 
-        Example usage as an async iterable (streaming):
+        Example usage as sync iterable (streaming):
 
-        ```typescript
-        const history = [{ role: 'user', content: "When will The Winds of Winter be released?" }];
-        for await (const fragment of model.respond(history)) {
-          process.stdout.write(fragment);
-        }
+        ```python
+        completion = model.respond([{
+            "role": "user",
+            "content": "When will The Winds of Winter be released?"
+        }])
+
+        for (fragment of completion):
+            print(fragment, end='')
         ```
 
-        If you wish to stream the result, but also getting the final prediction results (for example,
-        you wish to get the prediction stats), you can use the following pattern:
+        And asynchronous:
 
-        ```typescript
-        const history = [{ role: 'user', content: "When will The Winds of Winter be released?" }];
-        const prediction = model.respond(history);
-        for await (const fragment of prediction) {
-          process.stdout.write(fragment);
-        }
-        const result = await prediction;
-        console.log(result.stats);
+        ```python
+        completion = await model.respond([{
+            "role": "user",
+            "content": "When will The Winds of Winter be released?"
+        }])
+        async for fragment in completion:
+            print(fragment, end='')
         ```
 
-        :param history: The LLMChatHistory array to use for generating a response.
-        :param opts: Options for the prediction.
+        The result is already available in the internal buffer after streaming,
+        so calling `result()` (e.g. to get prediction stats) will not block.
+
+        The OngoingPrediction object can also be used to cancel the prediction
+        using `cancel()`.
+
+        Args:
+            history: The chat history to use for generating a completion.
+            opts: Options for the prediction, if any. Defaults to using the
+                options set in the LM Studio server.
+
+        Returns:
+            An OngoingPrediction object representing the prediction process.
         """
         try:
             resolved_context = self.__resolve_conversation_context(history)
@@ -423,55 +486,12 @@ class LLMDynamicHandle(DynamicHandle):
             )
         return self.predict(resolved_context, opts)
 
-    def predict(
-        self,
-        context: dc.LLMContext,
-        opts: Optional[dc.LLMPredictionOpts] = None,
-    ) -> (
-        comms.SyncOngoingPrediction
-        | Coroutine[Any, Any, comms.AsyncOngoingPrediction]
-    ):
-        config, extra_opts = self.__split_opts(opts)
-
-        if self._port.is_async():
-            OngoingPrediction = comms.AsyncOngoingPrediction
-            BufferedEvent = utils.AsyncBufferedEvent
-        else:
-            OngoingPrediction = comms.SyncOngoingPrediction
-            BufferedEvent = utils.SyncBufferedEvent
-
-        cancel_event, emit_cancel_event = BufferedEvent.create()
-        ongoing_prediction, finished, failed, push = OngoingPrediction.create(
-            emit_cancel_event
-        )
-
-        prediction_layers = self._internal_kv_config_stack.get("layers", [])
-        prediction_layers.append(
-            dc.KVConfigStackLayer(
-                layerName=dc.KVConfigLayerName.API_OVERRIDE,
-                config=self.__prediction_config_to_kv_config(config),
-            )
-        )
-
-        return self.__predict_internal(
-            self._specifier,
-            context,
-            {"layers": prediction_layers},
-            cancel_event,
-            extra_opts,
-            lambda fragment: push(fragment),
-            lambda stats,
-            model_info,
-            load_model_config,
-            prediction_config: finished(
-                stats, model_info, load_model_config, prediction_config
-            ),
-            lambda error: failed(error),
-            lambda x: x.get("ongoing_prediction"),
-            extra={"ongoing_prediction": ongoing_prediction},
-        )
-
     def unstable_get_context_length(self) -> utils.LiteralOrCoroutine[int]:
+        """Get the context length of the model.
+
+        Returns:
+            The context length of the model.
+        """
         return self.get_load_config(
             postprocess=lambda x: dc.find_key_in_kv_config(
                 x, "llm.load.contextLength"
@@ -484,6 +504,15 @@ class LLMDynamicHandle(DynamicHandle):
         context: dc.LLMContext,
         opts: Optional[dc.LLMApplyPromptTemplateOpts] = None,
     ) -> utils.LiteralOrCoroutine[str]:
+        """Apply a prompt template to the given context.
+
+        Args:
+            context: The context to apply the prompt template to.
+            opts: Options for applying the prompt template, if any.
+
+        Returns:
+            The formatted prompt template.
+        """
         return self._port.call_rpc(
             "applyPromptTemplate",
             {
@@ -498,6 +527,17 @@ class LLMDynamicHandle(DynamicHandle):
     def unstable_tokenize(
         self, input_string: str
     ) -> utils.LiteralOrCoroutine[List[int]]:
+        """Tokenize the input string.
+
+        Always tokenize using the exact model you will be using
+        for prediction, as tokenization can vary between models.
+
+        Args:
+            input_string: The string to tokenize.
+
+        Returns:
+            A list of integers representing the tokenized string.
+        """
         utils._assert(
             isinstance(input_string, str),
             "unstable_tokenize: input_string must be a string, got %s",
@@ -513,6 +553,14 @@ class LLMDynamicHandle(DynamicHandle):
     def unstable_count_tokens(
         self, input_string: str
     ) -> utils.LiteralOrCoroutine[int]:
+        """Count the number of tokens in the input string.
+
+        Args:
+            input_string: The string to count the tokens of.
+
+        Returns:
+            The number of tokens in the input string.
+        """
         utils._assert(
             isinstance(input_string, str),
             "unstable_count_tokens: input_string must be a string, got %s",

--- a/src/lmstudio_sdk/backend/handles/LLMDynamicHandle.py
+++ b/src/lmstudio_sdk/backend/handles/LLMDynamicHandle.py
@@ -224,8 +224,15 @@ class LLMDynamicHandle(DynamicHandle):
                 nonlocal finished
                 finished.set()
                 logger.debug("Prediction completed successfully.")
+                try:
+                    stats = dc.LLMPredictionStats(**message.get("stats", {}))
+                except Exception as e:
+                    logger.error(
+                        "Failed to parse prediction stats: %s", str(e)
+                    )
+                    stats = dc.LLMPredictionStats()
                 on_finished(
-                    message.get("stats", {}),
+                    stats,
                     message.get("descriptor", {}),
                     message.get("loadConfig", {}),
                     message.get("predictionConfig", {}),

--- a/src/lmstudio_sdk/backend/handles/LLMDynamicHandle.py
+++ b/src/lmstudio_sdk/backend/handles/LLMDynamicHandle.py
@@ -196,7 +196,6 @@ class LLMDynamicHandle(DynamicHandle):
         is_first_token = True
 
         def handle_fragments(message: dict):
-            """Handle incoming messages related to this prediction."""
             message_type = message.get("type", "")
             if message_type == "fragment":
                 on_fragment(message.get("fragment", ""))
@@ -239,7 +238,6 @@ class LLMDynamicHandle(DynamicHandle):
                 on_error(utils.ChannelError(message.get("error").get("title")))
 
         def cancel_send(channel_id):
-            """Send a cancel message to the server."""
             logger.info(
                 "Attempting to send cancel message to channel %d.", channel_id
             )

--- a/src/lmstudio_sdk/backend/handles/SpecificModel.py
+++ b/src/lmstudio_sdk/backend/handles/SpecificModel.py
@@ -7,9 +7,12 @@ from .LLMDynamicHandle import LLMDynamicHandle
 
 
 class SpecificModel(DynamicHandle):
-    # TODO: docstrings
+    """Represents a specific model on the remote server.
+
+    Retains a reference to the specific instance reference of the model.
+    """
+
     identifier: str
-    specifier: str
 
     def __init__(
         self,
@@ -30,18 +33,14 @@ class SpecificModel(DynamicHandle):
 
 
 class EmbeddingSpecificModel(EmbeddingDynamicHandle, SpecificModel):
-    """
-    Represents a specific loaded Embedding. Most Embedding related operations are inherited from
-    {@link EmbeddingDynamicHandle}.
+    """Represents a specific loaded embedding model.
 
-    :public:
+    Embedding related operations are inherited from EmbeddingDynamicHandle.
     """
 
 
 class LLMSpecificModel(LLMDynamicHandle, SpecificModel):
-    """
-    Represents a specific loaded LLM. Most LLM related operations are inherited from
-    {@link LLMDynamicHandle}.
+    """Represents a specific loaded LLM.
 
-    :public:
+    LLM related operations are inherited from LLMDynamicHandle.
     """

--- a/src/lmstudio_sdk/backend/handles/__init__.py
+++ b/src/lmstudio_sdk/backend/handles/__init__.py
@@ -1,4 +1,15 @@
-# TODO: docstring
+"""Handles and references to specific models on the server.
+
+Classes:
+    DynamicHandle: base class for dynamic handles.
+    EmbeddingDynamicHandle: dynamic handle for embedding models.
+    LLMDynamicHandle: dynamic handle for LLM models.
+    EmbeddingSpecificModel: reference to a specific embedding model.
+    LLMSpecificModel: reference to a specific LLM model.
+
+SpecificModels are returned by `get` and `load` methods of any
+`ModelNamespace`, and are used to interact with the model.
+"""
 
 from .DynamicHandle import DynamicHandle
 from .EmbeddingDynamicHandle import EmbeddingDynamicHandle

--- a/src/lmstudio_sdk/backend/namespaces/DiagnosticsNamespace.py
+++ b/src/lmstudio_sdk/backend/namespaces/DiagnosticsNamespace.py
@@ -21,7 +21,8 @@ class DiagnosticsLogEvent(TypedDict):
 
 
 class DiagnosticsNamespace(BaseNamespace):
-    # TODO: docstrings
+    """Method namespace for server diagnostics."""
+
     def unstable_stream_logs(
         self, listener: Callable[[DiagnosticsLogEvent], None]
     ) -> Callable[[], None]:
@@ -29,7 +30,12 @@ class DiagnosticsNamespace(BaseNamespace):
         Register a callback to receive log events. Return a function to stop receiving log events.
 
         This method is in alpha. Do not use this method in production yet.
-        :alpha:
+
+        Args:
+            listener: A callback that will receive log events.
+
+        Returns:
+            A function that will stop receiving log events.
         """
 
         utils._assert(

--- a/src/lmstudio_sdk/backend/namespaces/SystemNamespace.py
+++ b/src/lmstudio_sdk/backend/namespaces/SystemNamespace.py
@@ -6,6 +6,9 @@ import lmstudio_sdk.utils as utils
 from .BaseNamespace import BaseNamespace
 
 
+logger = utils.get_logger(__name__)
+
+
 class SystemNamespace(BaseNamespace):
     """Method namespace for LM Studio system functions."""
 
@@ -13,4 +16,16 @@ class SystemNamespace(BaseNamespace):
         self,
     ) -> utils.LiteralOrCoroutine[List[dc.DownloadedModel]]:
         """List all the models that have been downloaded."""
-        return self._port.call_rpc("listDownloadedModels", None, lambda x: x)
+
+        def process_downloaded_models(downloaded_models):
+            try:
+                return [
+                    dc.DownloadedModel(**model) for model in downloaded_models
+                ]
+            except Exception as e:
+                logger.error("Failed to process downloaded models: %s", e)
+                return downloaded_models
+
+        return self._port.call_rpc(
+            "listDownloadedModels", None, process_downloaded_models
+        )

--- a/src/lmstudio_sdk/backend/namespaces/SystemNamespace.py
+++ b/src/lmstudio_sdk/backend/namespaces/SystemNamespace.py
@@ -7,11 +7,10 @@ from .BaseNamespace import BaseNamespace
 
 
 class SystemNamespace(BaseNamespace):
-    # TODO: docstring
+    """Method namespace for LM Studio system functions."""
+
     def list_downloaded_models(
         self,
     ) -> utils.LiteralOrCoroutine[List[dc.DownloadedModel]]:
-        """
-        List all the models that have been downloaded.
-        """
+        """List all the models that have been downloaded."""
         return self._port.call_rpc("listDownloadedModels", None, lambda x: x)

--- a/src/lmstudio_sdk/backend/namespaces/__init__.py
+++ b/src/lmstudio_sdk/backend/namespaces/__init__.py
@@ -1,4 +1,11 @@
-# TODO: docstrings
+"""Namespaces for top-level server functions.
+
+Classes:
+    DiagnosticsNamespace: Method namespace for server diagnostics.
+    EmbeddingNamespace: Method namespace for embedding functions.
+    LLMNamespace: Method namespace for LLM functions.
+    SystemNamespace: Method namespace for LM Studio system functions.
+"""
 
 from .DiagnosticsNamespace import DiagnosticsNamespace
 from .ModelNamespace import EmbeddingNamespace, LLMNamespace

--- a/src/lmstudio_sdk/dataclasses/__init__.py
+++ b/src/lmstudio_sdk/dataclasses/__init__.py
@@ -24,7 +24,6 @@ from .configs import (
 )
 from .llms import (
     convert_dict_to_kv_config,
-    dict_to_stats,
     find_key_in_kv_config,
     KVConfig,
     KVConfigField,

--- a/src/lmstudio_sdk/dataclasses/__init__.py
+++ b/src/lmstudio_sdk/dataclasses/__init__.py
@@ -1,8 +1,14 @@
 # pylance: disable=unused-imports
 # flake8: noqa: f401
 # ruff: noqa: F401
+"""Dataclasses representing the data structures used in the LLM API.
 
-# TODO: docstring
+Most of these are typed dicts that are used to pass data to and from the LLM API,
+particularly in the case of long and repetitive argument dictionaries.
+
+For more information, see the individual classes and submodules.
+"""
+
 from .configs import (
     BaseLoadModelOpts,
     EmbeddingLoadModelConfig,
@@ -18,6 +24,7 @@ from .configs import (
 )
 from .llms import (
     convert_dict_to_kv_config,
+    dict_to_stats,
     find_key_in_kv_config,
     KVConfig,
     KVConfigField,

--- a/src/lmstudio_sdk/dataclasses/configs/BaseLoadModelOpts.py
+++ b/src/lmstudio_sdk/dataclasses/configs/BaseLoadModelOpts.py
@@ -7,51 +7,51 @@ TLoadModelConfig = TypeVar("TLoadModelConfig")
 
 
 class BaseLoadModelOpts(TypedDict, Generic[TLoadModelConfig]):
-    # TODO: docstring
+    """Base options for loading a model."""
+
     identifier: NotRequired[str]
-    """
-    The identifier to use for the loaded model.
+    """The identifier to use for the loaded model.
 
-    By default, the identifier is the same as the path (1st parameter). If the identifier already
-    exists, a number will be attached. This option allows you to specify the identifier to use.
+    By default, the identifier is the same as the path (1st parameter).
+    If the identifier already exists, a number will be attached.
+    This option allows you to specify the identifier to use.
 
-    However, when the identifier is specified and it is in use, an error will be thrown. If the
-    call is successful, it is guaranteed that the loaded model will have the specified identifier.
+    However, when the identifier is specified and it is in use,
+    an error will be thrown. If the call is successful, it is guaranteed
+    that the loaded model will have the specified identifier.
     """
 
     config: NotRequired[TLoadModelConfig]
-    """
-    The configuration to use when loading the model.
-    """
+    """The configuration to use when loading the model."""
 
     signal: NotRequired[Union[utils.AsyncAbortSignal, utils.SyncAbortSignal]]
-    """
-    An `AbortSignal` to cancel the model loading. This is useful if you wish to add a functionality
-    to cancel the model loading.
+    """An `AbortSignal` to cancel the model loading.
+
+    This is useful if you wish to add a functionality to cancel the model loading.
 
     Example usage:
 
     ```python
-    import asyncio
+    from lmstudio_sdk.utils import AsyncAbortSignal
 
     async def load_model():
-        ac = asyncio.get_event_loop().create_future()
+        ac = AsyncAbortSignal()
         model = await client.llm.load(
-            model="lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF",
-            signal=ac
+            "lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF",
+            {"signal": ac}
         )
 
         # Later, to cancel the model loading
         ac.cancel()
     ```
-
-    AbortSignal is the Python equivalent of JavaScript's AbortSignal for cancelling asynchronous operations.
     """
 
     on_progress: NotRequired[Callable[[float], None]]
-    """
-    A function that is called with the progress of the model loading. The function is called with a
-    number between 0 and 1, inclusive, representing the progress of the model loading.
+    """A callback to receive progress updates.
 
-    If an `on_progress` callback is provided, verbose progress logs will be disabled.
+    Called with a number between 0 and 1, inclusive,
+    representing the progress of the model loading.
+
+    If an `on_progress` callback is provided,
+    verbose progress logs will be disabled.
     """

--- a/src/lmstudio_sdk/dataclasses/configs/EmbeddingLoadModelConfig.py
+++ b/src/lmstudio_sdk/dataclasses/configs/EmbeddingLoadModelConfig.py
@@ -4,37 +4,22 @@ from .LLMLoadModelConfig import LLMLlamaAccelerationSetting
 
 
 class EmbeddingLoadModelConfig(TypedDict):
-    # TODO: docstring
-    """
-    Configuration for loading an embedding model.
-    """
+    """Configuration for loading an embedding model."""
 
     gpu_offload: NotRequired[LLMLlamaAccelerationSetting]
-    """
-    GPU offload settings for the model.
-    """
+    """GPU offload settings for the model."""
 
     context_length: NotRequired[int]
-    """
-    The context length to use for the model.
-    """
+    """The context length to use for the model."""
 
     rope_frequency_base: NotRequired[float]
-    """
-    The base frequency for RoPE (Rotary Positional Embedding).
-    """
+    """The base frequency for RoPE (Rotary Positional Embedding)."""
 
     rope_frequency_scale: NotRequired[float]
-    """
-    The frequency scale for RoPE (Rotary Positional Embedding).
-    """
+    """The frequency scale for RoPE (Rotary Positional Embedding)."""
 
     keep_model_in_memory: NotRequired[bool]
-    """
-    Whether to keep the model in memory.
-    """
+    """Whether to keep the model in memory."""
 
     try_mmap: NotRequired[bool]
-    """
-    Whether to try memory-mapping the model.
-    """
+    """Whether to try memory-mapping the model."""

--- a/src/lmstudio_sdk/dataclasses/configs/LLMLoadModelConfig.py
+++ b/src/lmstudio_sdk/dataclasses/configs/LLMLoadModelConfig.py
@@ -2,11 +2,12 @@ from typing import List, Literal, NotRequired, TypedDict, Union
 
 
 LLMLlamaAccelerationOffloadRatio = Union[float, Literal["max", "off"]]
-# TODO: docstring
-"""
-How much of the model's work should be offloaded to the GPU. The value should be between 0 and 1.
-A value of 0 means that no layers are offloaded to the GPU, while a value of 1 means that all
-layers (that can be offloaded) are offloaded to the GPU.
+"""How much of the model's work should be offloaded to the GPU.
+
+The value should be between 0 and 1.
+A value of 0 means that no layers are offloaded to the GPU,
+while a value of 1 means that all layers (that can be offloaded)
+are offloaded to the GPU.
 
 This type can be:
 - A float between 0 and 1
@@ -16,56 +17,46 @@ This type can be:
 
 
 class LLMLlamaAccelerationSetting(TypedDict):
-    # TODO: docstring
-    """
-    Settings related to offloading work to the GPU.
-    """
+    """Settings related to offloading work to the GPU."""
 
     ratio: LLMLlamaAccelerationOffloadRatio
-    """
-    The offload ratio for GPU acceleration.
-    """
+    """The offload ratio for GPU acceleration."""
 
     main_gpu: int
-    """
-    The index of the main GPU to use.
-    """
+    """The index of the main GPU to use."""
 
     tensor_split: List[float]
-    """
-    The tensor split configuration for multi-GPU setups.
-    """
+    """The tensor split configuration for multi-GPU setups."""
 
 
 class LLMLoadModelConfig(TypedDict):
-    # TODO: docstring
-    """
-    Configuration for loading an LLM model.
-    """
+    """Configuration for loading an LLM model."""
 
     gpu_offload: NotRequired[Union[LLMLlamaAccelerationSetting, float]]
-    """
-    How much of the model's work should be offloaded to the GPU. The value should be between 0 and 1.
-    A value of 0 means that no layers are offloaded to the GPU, while a value of 1 means that all
-    layers (that can be offloaded) are offloaded to the GPU.
+    """How much of the model's work should be offloaded to the GPU.
+
+    The value should be between 0 and 1.
+    A value of 0 means that no layers are offloaded to the GPU,
+    while a value of 1 means that all layers (that can be offloaded)
+    are offloaded to the GPU.
     """
 
     context_length: NotRequired[int]
-    """
-    The size of the context length in number of tokens. This will include both the prompts and the
-    responses. Once the context length is exceeded, the value set in
-    LLMPredictionConfigBase.context_overflow_policy is used to determine the behavior.
+    """The size of the context length in number of tokens.
 
-    See LLMContextOverflowPolicy for more information.
+    This will include both the prompts and the responses.
+    Once the context length is exceeded, the value set in
+    LLMPredictionConfigBase.context_overflow_policy is used
+    to determine the behavior.
+
+    See `LLMContextOverflowPolicy` for more information.
     """
 
     rope_frequency_base: NotRequired[float]
     rope_frequency_scale: NotRequired[float]
 
     eval_batch_size: NotRequired[int]
-    """
-    Prompt evaluation batch size.
-    """
+    """Prompt evaluation batch size."""
 
     flash_attention: NotRequired[bool]
     keep_model_in_memory: NotRequired[bool]

--- a/src/lmstudio_sdk/dataclasses/configs/LLMPredictionOpts.py
+++ b/src/lmstudio_sdk/dataclasses/configs/LLMPredictionOpts.py
@@ -6,61 +6,64 @@ from .LLMStructuredPredictionSetting import LLMStructuredPredictionSetting
 LLMContextOverflowPolicy = Literal[
     "stopAtLimit", "truncateMiddle", "rollingWindow"
 ]
-# TODO: docstring
-"""
-Behavior for when the generated tokens length exceeds the context window size. Only the following values are allowed:
+"""Behavior when the generated tokens length exceeds the context window size.
 
-- `stopAtLimit`: Stop the prediction when the generated tokens length exceeds the context window
-  size. If the generation is stopped because of this limit, the `stopReason` in the prediction
+Only the following values are allowed:
+
+- `stopAtLimit`: Stop the prediction when the generated tokens length
+  exceeds the context window size. If the generation is stopped
+  because of this limit, the `stopReason` in the prediction
   stats will be set to `contextLengthReached`.
-- `truncateMiddle`: Keep the system prompt and the first user message, truncate middle.
+- `truncateMiddle`: Keep the system prompt and the first user message,
+  truncate middle.
 - `rollingWindow`: Maintain a rolling window and truncate past messages.
 """
 
 
 class LLMPredictionConfig(TypedDict):
-    # TODO: docstring
-    """
-    Shared config for running predictions on an LLM.
-    """
+    """Shared config for running predictions on an LLM."""
 
     max_predicted_tokens: NotRequired[int]
-    """
-    Number of tokens to predict at most. If set to -1, the model will predict as many tokens as it
-    wants.
+    """Number of tokens to predict at most.
 
-    When the prediction is stopped because of this limit, the `stopReason` in the prediction stats
-    will be set to `max_predicted_tokensReached`.
+    If set to -1, the model will predict as many tokens as it wants.
 
-    See `LLMPredictionStopReason` for other reasons that a prediction might stop.
+    When the prediction is stopped because of this limit, the `stopReason`
+    in the prediction stats will be set to `max_predicted_tokensReached`.
+
+    See `LLMPredictionStopReason` for other reasons
+    that a prediction might stop.
     """
 
     temperature: NotRequired[float]
-    """
-    The temperature parameter for the prediction model. A higher value makes the predictions more
-    random, while a lower value makes the predictions more deterministic. The value should be
-    between 0 and 1.
+    """The temperature parameter for the prediction model.
+
+    A higher value makes the predictions more random,
+    while a lower value makes the predictions more deterministic.
+    The value should be between 0 and 1.
     """
 
     stop_strings: NotRequired[List[str]]
-    """
-    An array of strings. If the model generates one of these strings, the prediction will stop.
+    """An array of strings that will stop prediction if encountered.
 
-    When the prediction is stopped because of this limit, the `stopReason` in the prediction stats
-    will be set to `stopStringFound`.
+    When the prediction is stopped because of this limit,
+    the `stopReason` in the prediction stats will be set to `stopStringFound`.
 
-    See `LLMPredictionStopReason` for other reasons that a prediction might stop.
+    See `LLMPredictionStopReason` for other reasons
+    that a prediction might stop.
     """
 
     context_overflow_policy: NotRequired[LLMContextOverflowPolicy]
-    """
-    The behavior for when the generated tokens length exceeds the context window size. The allowed
-    values are:
+    """The behavior for when the generated tokens length exceeds the context window size.
 
-    - `stopAtLimit`: Stop the prediction when the generated tokens length exceeds the context
-      window size. If the generation is stopped because of this limit, the `stopReason` in the
-      prediction stats will be set to `contextLengthReached`
-    - `truncateMiddle`: Keep the system prompt and the first user message, truncate middle.
+    Only the following values are allowed:
+
+    - `stopAtLimit`: Stop the prediction when the generated tokens length
+      exceeds the context window size. If the generation is stopped
+      because of this limit, the `stopReason` in the prediction
+      stats will be set to `contextLengthReached`.
+    - `truncateMiddle`: Keep the system prompt and the first user message,
+      truncate middle.
     - `rollingWindow`: Maintain a rolling window and truncate past messages.
     """
 
@@ -73,28 +76,29 @@ class LLMPredictionConfig(TypedDict):
 
 
 class LLMPredictionExtraOpts(TypedDict):
-    # TODO: docstring
-    on_prompt_processing_progress: NotRequired[Callable[[float], None]]
-    """
-    A callback that is called when the model is processing the prompt. The callback is called with
-    a number between 0 and 1, representing the progress of the prompt processing.
+    """Internal options for prediction that are not passed to the server."""
 
-    Prompt processing progress callbacks will only be called before the first token is emitted.
+    on_prompt_processing_progress: NotRequired[Callable[[float], None]]
+    """A callback that is called when the model is processing the prompt.
+
+    The callback is called with a number between 0 and 1,
+    representing the progress of the prompt processing.
+
+    Prompt processing progress callbacks will only be called
+    before the first token is emitted.
     """
 
     on_first_token: NotRequired[Callable[[], None]]
-    """
-    A callback that is called when the model has output the first token.
-    """
+    """A callback that is called when the model has output the first token."""
 
 
 class LLMPredictionOpts(LLMPredictionConfig, LLMPredictionExtraOpts):
-    # TODO: docstring
-    """
-    Shared options for any prediction methods (`.complete`/`.respond`).
+    """Shared options for any prediction methods (`.complete`/`.respond`).
 
-    Note, this class extends the `LLMPredictionConfig` class, which contains parameters that
-    you can override for the LLM. See `LLMPredictionConfig` for more information.
+    Note, this class extends the `LLMPredictionConfig` class,
+    which contains parameters that you can override for the LLM.
+
+    See `LLMPredictionConfig` for more information.
     """
 
     pass

--- a/src/lmstudio_sdk/dataclasses/configs/LLMStructuredPredictionSetting.py
+++ b/src/lmstudio_sdk/dataclasses/configs/LLMStructuredPredictionSetting.py
@@ -5,13 +5,14 @@ LLMStructuredPredictionSetting = Union[
     Dict[Literal["type"], Literal["none"]],
     Dict[Literal["type", "jsonSchema"], Union[Literal["json"], Any]],
 ]
-# TODO: docstring
-"""
-Settings for structured prediction. Structured prediction is a way to force the model to generate
+"""Settings for structured prediction.
+
+Structured prediction is a way to force the model to generate
 predictions that conform to a specific structure.
 
-For example, you can use structured prediction to make the model only generate valid JSON, or
-even JSON that conforms to a specific schema (i.e. having strict types).
+For example, you can use structured prediction to make the model
+only generate valid JSON, or even JSON that conforms to
+a specific schema (i.e. having strict types).
 
 Some examples:
 
@@ -24,7 +25,8 @@ prediction = model.complete("...", {
 })
 ```
 
-Only generate JSON that conforms to a specific schema (See https://json-schema.org/ for more
+Only generate JSON that conforms to a specific schema
+(See https://json-schema.org/ for more
 information on authoring JSON schema):
 
 ```python
@@ -42,17 +44,21 @@ prediction = model.complete("...", {
 })
 ```
 
-By default, `{"type": "none"}` is used, which means no structured prediction is used.
+By default, `{"type": "none"}` is used,
+which means no structured prediction is used.
 
 Caveats:
 
-- Although the model is forced to generate predictions that conform to the specified structure,
-  the prediction may be interrupted (for example, if the user stops the prediction). When that
-  happens, the partial result may not conform to the specified structure. Thus, always check the
-  prediction result before using it, for example, by wrapping the `json.loads` inside a try-except
-  block.
-- In certain cases, the model may get stuck. For example, when forcing it to generate valid JSON,
-  it may generate an opening brace `{` but never generate a closing brace `}`. In such cases, the
-  prediction will go on forever until the context length is reached, which can take a long time.
-  Therefore, it is recommended to always set a `max_predicted_tokens` limit.
+- Although the model is forced to generate predictions that conform
+  to the specified structure, the prediction may be interrupted
+  (for example, if the user stops the prediction). When that happens,
+  the partial result may not conform to the specified structure.
+  Thus, always check the prediction result before using it,
+  for example, by wrapping the `json.loads` inside a try-catch block.
+- In certain cases, the model may get stuck. For example, when forcing it
+  to generate valid JSON, it may generate an opening brace `{`
+  but never generate a closing brace `}`. In such cases, the prediction
+  will go on forever until the context length is reached,
+  which can take a long time. Therefore, it is recommended
+  to always set a `max_predicted_tokens` limit.
 """

--- a/src/lmstudio_sdk/dataclasses/configs/__init__.py
+++ b/src/lmstudio_sdk/dataclasses/configs/__init__.py
@@ -1,4 +1,19 @@
-# TODO: docstring
+"""Configuration dict dataclasses for various operations.
+
+Classes:
+    BaseLoadModelOpts: Base options for loading a model.
+    EmbeddingLoadModelConfig: Configuration for loading an embedding model.
+    LLMApplyPromptTemplateOpts: Options for applying a prompt template.
+    LLMContextOverflowPolicy: Behavior when the generated tokens length exceeds the context window size.
+    LLMLlamaAccelerationSetting: Settings related to offloading work to the GPU.
+    LLMLlamaAccelerationOffloadRatio: How much of the model's work should be offloaded to the GPU.
+    LLMLoadModelConfig: Configuration for loading an LLM model.
+    LLMPredictionConfig: Shared config for running predictions on an LLM.
+    LLMPredictionExtraOpts: Internal options for prediction that are not passed to the server.
+    LLMPredictionOpts: Shared options for any prediction methods.
+    LLMStructuredPredictionSetting: Structured prediction settings for an LLM model.
+"""
+
 from .BaseLoadModelOpts import BaseLoadModelOpts
 from .EmbeddingLoadModelConfig import EmbeddingLoadModelConfig
 from .LLMApplyPromptTemplateOpts import LLMApplyPromptTemplateOpts

--- a/src/lmstudio_sdk/dataclasses/llms/KVConfig.py
+++ b/src/lmstudio_sdk/dataclasses/llms/KVConfig.py
@@ -3,13 +3,15 @@ from typing import Any, List, TypedDict
 
 
 class KVConfigField(TypedDict):
-    """Represents a key-value configuration field."""
+    """A key-value configuration field."""
+
     key: str
     value: Any
 
 
 class KVConfig(TypedDict):
-    """Represents a key-value configuration object."""
+    """A key-value configuration object."""
+
     fields: List[KVConfigField]
 
 
@@ -31,7 +33,8 @@ def find_key_in_kv_config(kv_config: KVConfig, key: str) -> Any:
 
 
 class KVConfigLayerName(str, enum.Enum):
-    # TODO docstrings
+    """A key-value configuration layer name."""
+
     # Config that is currently loaded by the model
     CURRENTLY_LOADED = "currentlyLoaded"
 
@@ -64,11 +67,13 @@ class KVConfigLayerName(str, enum.Enum):
 
 
 class KVConfigStackLayer(TypedDict):
-    """Represents a layer in a KVConfigStack."""
+    """A key-value configuration stack layer."""
+
     layerName: KVConfigLayerName
     config: KVConfig
 
 
 class KVConfigStack(TypedDict):
-    """Represents a stack of KVConfigLayers."""
+    """A key-value configuration stack."""
+
     layers: List[KVConfigStackLayer]

--- a/src/lmstudio_sdk/dataclasses/llms/LLMChatHistory.py
+++ b/src/lmstudio_sdk/dataclasses/llms/LLMChatHistory.py
@@ -2,18 +2,18 @@ from typing import List, Literal, TypedDict, Union
 
 
 LLMChatHistoryMessageContent = List["LLMChatHistoryMessageContentPart"]
-"""Represents the content of a message in the history."""
+"""The content of a message in the history."""
 
 
 class LLMChatHistoryMessageContentPartText(TypedDict):
-    """Represents a text in a message in the history."""
+    """The text in a message in the history."""
 
     type: Literal["text"]
     text: str
 
 
 class LLMChatHistoryMessageContentPartImage(TypedDict):
-    """Represents an image in a message in the history."""
+    """The image in a message in the history."""
 
     type: Literal["imageBase64"]
     base64: str
@@ -22,10 +22,10 @@ class LLMChatHistoryMessageContentPartImage(TypedDict):
 LLMChatHistoryMessageContentPart = Union[
     LLMChatHistoryMessageContentPartText, LLMChatHistoryMessageContentPartImage
 ]
-"""Represents a part of the content of a message in the history."""
+"""A part of the content of a message in the history."""
 
 LLMChatHistoryRole = Literal["system", "user", "assistant"]
-"""Represents a role in a specific message in the history.
+"""A role in a specific message in the history.
 
 This is a string enum, and can only be one of the following values:
 
@@ -37,32 +37,32 @@ This is a string enum, and can only be one of the following values:
 
 
 class LLMChatHistoryMessage(TypedDict):
-    """Represents a single message in the history."""
+    """A single message in the history."""
 
     role: LLMChatHistoryRole
     content: LLMChatHistoryMessageContent
 
 
 LLMChatHistory = List[LLMChatHistoryMessage]
-"""Represents the history of a conversation as an array of messages."""
+"""The history of a conversation as an array of messages."""
 
 
 class LLMContext(TypedDict):
-    """Represents a raw context object that can be fed into the model."""
+    """A raw context object that can be fed into the model."""
 
     history: LLMChatHistory
 
 
 LLMCompletionContextInput = str
-"""Represents the input context for a completion request."""
+"""The input context for a completion request."""
 
 
 class LLMConversationContextInputItem(TypedDict):
-    """Represents a single message in the conversation context input."""
+    """A single message in the conversation context input."""
 
     role: LLMChatHistoryRole
     content: str
 
 
 LLMConversationContextInput = List[LLMConversationContextInputItem]
-"""Represents the input context for a conversation request."""
+"""The input context for a conversation request."""

--- a/src/lmstudio_sdk/dataclasses/llms/LLMPredictionStats.py
+++ b/src/lmstudio_sdk/dataclasses/llms/LLMPredictionStats.py
@@ -90,30 +90,18 @@ class LLMPredictionStats:
 
     def __init__(
         self,
-        stop_reason: LLMPredictionStopReason,
-        tokens_per_second: Optional[float],
-        num_gpu_layers: Optional[int],
-        time_to_first_token_sec: Optional[float],
-        prompt_tokens_count: Optional[int],
-        predicted_tokens_count: Optional[int],
-        total_tokens_count: Optional[int],
+        stopReason: LLMPredictionStopReason,
+        tokensPerSecond: Optional[float],
+        numGpuLayers: Optional[int],
+        timeToFirstTokenSec: Optional[float],
+        promptTokensCount: Optional[int],
+        predictedTokensCount: Optional[int],
+        totalTokensCount: Optional[int],
     ):
-        self.stop_reason = stop_reason
-        self.tokens_per_second = tokens_per_second
-        self.num_gpu_layers = num_gpu_layers
-        self.time_to_first_token_sec = time_to_first_token_sec
-        self.prompt_tokens_count = prompt_tokens_count
-        self.predicted_tokens_count = predicted_tokens_count
-        self.total_tokens_count = total_tokens_count
-
-
-def dict_to_stats(d: dict) -> LLMPredictionStats:
-    return LLMPredictionStats(
-        stop_reason=LLMPredictionStopReason(d.get("stop_reason")),
-        tokens_per_second=d.get("tokens_per_second"),
-        num_gpu_layers=d.get("num_gpu_layers"),
-        time_to_first_token_sec=d.get("time_to_first_token_sec"),
-        prompt_tokens_count=d.get("prompt_tokens_count"),
-        predicted_tokens_count=d.get("predicted_tokens_count"),
-        total_tokens_count=d.get("total_tokens_count"),
-    )
+        self.stop_reason = stopReason
+        self.tokens_per_second = tokensPerSecond
+        self.num_gpu_layers = numGpuLayers
+        self.time_to_first_token_sec = timeToFirstTokenSec
+        self.prompt_tokens_count = promptTokensCount
+        self.predicted_tokens_count = predictedTokensCount
+        self.total_tokens_count = totalTokensCount

--- a/src/lmstudio_sdk/dataclasses/llms/LLMPredictionStats.py
+++ b/src/lmstudio_sdk/dataclasses/llms/LLMPredictionStats.py
@@ -1,26 +1,31 @@
 import enum
-from typing import NotRequired, TypedDict
+from typing import Optional
 
 
 class LLMPredictionStopReason(str, enum.Enum):
-    # TODO docstrings
-    """
-    Represents the reason why a prediction stopped. Only the following values are possible:
+    """The reason why a prediction stopped.
 
-    - `userStopped`: The user stopped the prediction. This includes calling the `cancel` method on
-      the `SyncOngoingPrediction` object.
+    Only the following values are possible:
+
+    - `userStopped`: The user stopped the prediction.
+      This includes calling the `cancel` method
+      on the `OngoingPrediction` object.
     - `modelUnloaded`: The model was unloaded during the prediction.
     - `failed`: An error occurred during the prediction.
-    - `eosFound`: The model predicted an end-of-sequence token, which is a way for the model to
-      indicate that it "thinks" the sequence is complete.
-    - `stopStringFound`: A stop string was found in the prediction. (Stop strings can be specified
-      with the `stop_strings` config option. This stop reason will only occur if the `stop_strings`
-      config option is set to an array of strings.)
-    - `maxPredictedTokensReached`: The maximum number of tokens to predict was reached. (Length limit
-      can be specified with the `maxPredictedTokens` config option. This stop reason will only occur
-      if the `maxPredictedTokens` config option is set to a value other than -1.)
-    - `contextLengthReached`: The context length was reached. This stop reason will only occur if the
-      `context_overflow_policy` is set to `stopAtLimit`.
+    - `eosFound`: The model predicted an end-of-sequence token,
+      which is a way for the model to indicate that it "thinks"
+      the sequence is complete.
+    - `stopStringFound`: A stop string was found in the prediction.
+      Stop strings can be specified with the `stop_strings` config option.
+      This stop reason will only occur if the `stop_strings`
+      config option is set to an array of strings.
+    - `maxPredictedTokensReached`: The maximum number of tokens to predict
+      was reached. Length limit can be specified with the `maxPredictedTokens`
+      config option. This stop reason will only occur if
+      the `maxPredictedTokens` config option is set to a value other than -1.
+    - `contextLengthReached`: The context length was reached.
+      This stop reason will only occur if the `context_overflow_policy`
+      is set to `stopAtLimit`.
     """
 
     USER_STOPPED = "userStopped"
@@ -32,63 +37,83 @@ class LLMPredictionStopReason(str, enum.Enum):
     CONTEXT_LENGTH_REACHED = "contextLengthReached"
 
 
-class LLMPredictionStats(TypedDict):
-    # TODO docstrings
-    """
-    @public
-    """
+class LLMPredictionStats:
+    """Statistics about a prediction."""
 
     stop_reason: LLMPredictionStopReason
-    """
-    The reason why the prediction stopped.
+    """The reason why the prediction stopped.
 
-    This is a string enum with the following possible values:
+    Only the following values are possible:
 
-    - `userStopped`: The user stopped the prediction. This includes calling the `cancel` method on
-      the `SyncOngoingPrediction` object.
+    - `userStopped`: The user stopped the prediction.
+      This includes calling the `cancel` method
+      on the `OngoingPrediction` object.
     - `modelUnloaded`: The model was unloaded during the prediction.
     - `failed`: An error occurred during the prediction.
-    - `eosFound`: The model predicted an end-of-sequence token, which is a way for the model to
-      indicate that it "thinks" the sequence is complete.
-    - `stopStringFound`: A stop string was found in the prediction. (Stop strings can be specified
-      with the `stop_strings` config option. This stop reason will only occur if the `stop_strings`
-      config option is set.)
-    - `maxPredictedTokensReached`: The maximum number of tokens to predict was reached. (Length
-      limit can be specified with the `maxPredictedTokens` config option. This stop reason will
-      only occur if the `maxPredictedTokens` config option is set to a value other than -1.)
-    - `contextLengthReached`: The context length was reached. This stop reason will only occur if
-      the `context_overflow_policy` is set to `stopAtLimit`.
+    - `eosFound`: The model predicted an end-of-sequence token,
+      which is a way for the model to indicate that it "thinks"
+      the sequence is complete.
+    - `stopStringFound`: A stop string was found in the prediction.
+      Stop strings can be specified with the `stop_strings` config option.
+      This stop reason will only occur if the `stop_strings`
+      config option is set to an array of strings.
+    - `maxPredictedTokensReached`: The maximum number of tokens to predict
+      was reached. Length limit can be specified with the `maxPredictedTokens`
+      config option. This stop reason will only occur if
+      the `maxPredictedTokens` config option is set to a value other than -1.
+    - `contextLengthReached`: The context length was reached.
+      This stop reason will only occur if the `context_overflow_policy`
+      is set to `stopAtLimit`.
     """
 
-    tokens_per_second: NotRequired[float]
-    """
-    The average number of tokens predicted per second.
+    tokens_per_second: Optional[float]
+    """The average number of tokens predicted per second.
 
-    Note: This value can be None in the case of a very short prediction which results in a
-    NaN or a Infinity value.
-    """
-
-    num_gpu_layers: NotRequired[int]
-    """
-    The number of GPU layers used in the prediction.
+    Note: This value can be None in the case of a very short prediction,
+    which results in a NaN or a Infinity value.
     """
 
-    time_to_first_token_sec: NotRequired[float]
-    """
-    The time it took to predict the first token in seconds.
-    """
+    num_gpu_layers: Optional[int]
+    """The number of GPU layers used in the prediction."""
 
-    prompt_tokens_count: NotRequired[int]
-    """
-    The number of tokens that were supplied.
-    """
+    time_to_first_token_sec: Optional[float]
+    """The time it took to predict the first token in seconds."""
 
-    predicted_tokens_count: NotRequired[int]
-    """
-    The number of tokens that were predicted.
-    """
+    prompt_tokens_count: Optional[int]
+    """The number of tokens that were supplied."""
 
-    total_tokens_count: NotRequired[int]
-    """
-    The total number of tokens. This is the sum of the prompt tokens and the predicted tokens.
-    """
+    predicted_tokens_count: Optional[int]
+    """The number of tokens that were predicted."""
+
+    total_tokens_count: Optional[int]
+    """The total number of tokens. This is the sum of the prompt tokens and the predicted tokens."""
+
+    def __init__(
+        self,
+        stop_reason: LLMPredictionStopReason,
+        tokens_per_second: Optional[float],
+        num_gpu_layers: Optional[int],
+        time_to_first_token_sec: Optional[float],
+        prompt_tokens_count: Optional[int],
+        predicted_tokens_count: Optional[int],
+        total_tokens_count: Optional[int],
+    ):
+        self.stop_reason = stop_reason
+        self.tokens_per_second = tokens_per_second
+        self.num_gpu_layers = num_gpu_layers
+        self.time_to_first_token_sec = time_to_first_token_sec
+        self.prompt_tokens_count = prompt_tokens_count
+        self.predicted_tokens_count = predicted_tokens_count
+        self.total_tokens_count = total_tokens_count
+
+
+def dict_to_stats(d: dict) -> LLMPredictionStats:
+    return LLMPredictionStats(
+        stop_reason=LLMPredictionStopReason(d.get("stop_reason")),
+        tokens_per_second=d.get("tokens_per_second"),
+        num_gpu_layers=d.get("num_gpu_layers"),
+        time_to_first_token_sec=d.get("time_to_first_token_sec"),
+        prompt_tokens_count=d.get("prompt_tokens_count"),
+        predicted_tokens_count=d.get("predicted_tokens_count"),
+        total_tokens_count=d.get("total_tokens_count"),
+    )

--- a/src/lmstudio_sdk/dataclasses/llms/PredictionResult.py
+++ b/src/lmstudio_sdk/dataclasses/llms/PredictionResult.py
@@ -1,12 +1,10 @@
-from typing import TypedDict
-
 import lmstudio_sdk.dataclasses.models as models
 
 from .KVConfig import KVConfig
 from .LLMPredictionStats import LLMPredictionStats
 
 
-class PredictionResult(TypedDict):
+class PredictionResult:
     """Represents the result of a prediction.
 
     The most notable property is `content`,
@@ -29,3 +27,17 @@ class PredictionResult(TypedDict):
 
     prediction_config: KVConfig
     """The configuration used for the prediction."""
+
+    def __init__(
+        self,
+        content: str,
+        stats: LLMPredictionStats,
+        model_info: models.ModelDescriptor,
+        load_config: KVConfig,
+        prediction_config: KVConfig,
+    ):
+        self.content = content
+        self.stats = stats
+        self.model_info = model_info
+        self.load_config = load_config
+        self.prediction_config = prediction_config

--- a/src/lmstudio_sdk/dataclasses/llms/__init__.py
+++ b/src/lmstudio_sdk/dataclasses/llms/__init__.py
@@ -1,8 +1,30 @@
 # pylance: disable=unused-imports
 # flake8: noqa: f401
 # ruff: noqa: F401
+"""Dataclasses representing the data structures used in the LLM API.
 
-# TODO: docstring
+Classes:
+    KVConfig: A key-value configuration object.
+    KVConfigField: A key-value configuration field.
+    KVConfigLayerName: A key-value configuration layer name.
+    KVConfigStack: A key-value configuration stack.
+    KVConfigStackLayer: A key-value configuration stack layer.
+    LLMChatHistory: The history of a conversation as an array of messages.
+    LLMChatHistoryMessage: A single message in the history.
+    LLMChatHistoryMessageContent: The content of a message in the history.
+    LLMChatHistoryMessageContentPart: A part of the content of a message in the history.
+    LLMChatHistoryMessageContentPartImage: The image in a message in the history.
+    LLMChatHistoryMessageContentPartText: The text in a message in the history.
+    LLMChatHistoryRole: A role in a specific message in the history.
+    LLMContext: A raw context object that can be fed into the model.
+    LLMCompletionContextInput: The input context for a conversation request.
+    LLMConversationContextInput: A conversation context input object.
+    LLMConversationContextInputItem: A single message in the conversation context input.
+    LLMPredictionStats: Statistics about a prediction.
+    LLMPredictionStopReason: The reason why a prediction stopped.
+    PredictionResult: Represents the result of a prediction.
+"""
+
 from .LLMChatHistory import (
     LLMChatHistory,
     LLMChatHistoryMessage,
@@ -25,7 +47,11 @@ from .KVConfig import (
     KVConfigStack,
     KVConfigStackLayer,
 )
-from .LLMPredictionStats import LLMPredictionStopReason, LLMPredictionStats
+from .LLMPredictionStats import (
+    dict_to_stats,
+    LLMPredictionStopReason,
+    LLMPredictionStats,
+)
 from .PredictionResult import PredictionResult
 
 __all__ = [

--- a/src/lmstudio_sdk/dataclasses/llms/__init__.py
+++ b/src/lmstudio_sdk/dataclasses/llms/__init__.py
@@ -47,11 +47,7 @@ from .KVConfig import (
     KVConfigStack,
     KVConfigStackLayer,
 )
-from .LLMPredictionStats import (
-    dict_to_stats,
-    LLMPredictionStopReason,
-    LLMPredictionStats,
-)
+from .LLMPredictionStats import LLMPredictionStopReason, LLMPredictionStats
 from .PredictionResult import PredictionResult
 
 __all__ = [

--- a/src/lmstudio_sdk/dataclasses/models/DownloadedModel.py
+++ b/src/lmstudio_sdk/dataclasses/models/DownloadedModel.py
@@ -1,7 +1,7 @@
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal, Optional
 
 
-class DownloadedModel(TypedDict):
+class DownloadedModel:
     """Represents a model that exists locally and can be loaded."""
 
     type: Literal["llm", "embedding"]
@@ -13,5 +13,17 @@ class DownloadedModel(TypedDict):
     size_bytes: int
     """The size of the model in bytes."""
 
-    architecture: NotRequired[str]
+    architecture: Optional[str]
     """The architecture of the model."""
+
+    def __init__(
+        self,
+        type: Literal["llm", "embedding"],
+        path: str,
+        sizeBytes: int,
+        architecture: Optional[str] = None,
+    ):
+        self.type = type
+        self.path = path
+        self.size_bytes = sizeBytes
+        self.architecture = architecture

--- a/src/lmstudio_sdk/dataclasses/models/ModelDescriptor.py
+++ b/src/lmstudio_sdk/dataclasses/models/ModelDescriptor.py
@@ -2,11 +2,10 @@ from typing import TypedDict
 
 
 class ModelDescriptor(TypedDict):
-    """Describes a specific loaded LLM."""
+    """Describes a specific loaded model."""
 
     identifier: str
-    """
-    The identifier of the model.
+    """The identifier of the model.
 
     Set when loading the model. Defaults to the same as the path.
     Identifier identifies a currently loaded model.

--- a/src/lmstudio_sdk/dataclasses/models/ModelQuery.py
+++ b/src/lmstudio_sdk/dataclasses/models/ModelQuery.py
@@ -6,7 +6,7 @@ ModelDomainType = Literal["llm", "embedding"]
 
 
 class ModelQuery(TypedDict):
-    """Represents a query for a loaded LLM."""
+    """A query for a loaded model."""
 
     domain: NotRequired[ModelDomainType]
     """The domain of the model."""

--- a/src/lmstudio_sdk/dataclasses/models/ModelSpecifier.py
+++ b/src/lmstudio_sdk/dataclasses/models/ModelSpecifier.py
@@ -3,19 +3,20 @@ from typing import Literal, TypedDict, Union
 from .ModelQuery import ModelQuery
 
 
+# isn't this terribly named?
 class QueryModel(TypedDict):
-    """Represents a query for a model."""
+    """A query for a model."""
 
     type: Literal["query"]
     query: ModelQuery
 
 
 class InstanceReferenceModel(TypedDict):
-    """Represents a model by instance reference."""
+    """A model instance reference."""
 
     type: Literal["instanceReference"]
     instance_reference: str
 
 
 ModelSpecifier = Union[QueryModel, InstanceReferenceModel]
-"""Represents a model specifier."""
+"""A model specifier."""

--- a/src/lmstudio_sdk/dataclasses/models/__init__.py
+++ b/src/lmstudio_sdk/dataclasses/models/__init__.py
@@ -1,4 +1,14 @@
-# TODO: docstring
+"""Dataclasses for models and model management.
+
+Classes:
+    DownloadedModel: Represents a model that exists locally and can be loaded.
+    InstanceReferenceModel: A model instance reference.
+    ModelDescriptor: Describes a specific loaded model.
+    ModelDomainType: The domain of a model.
+    ModelQuery: A query for a loaded model.
+    ModelSpecifier: A specifier for a model.
+    QueryModel: A query for a model.
+"""
 
 from .DownloadedModel import DownloadedModel
 from .ModelDescriptor import ModelDescriptor

--- a/src/lmstudio_sdk/utils/AbortSignal.py
+++ b/src/lmstudio_sdk/utils/AbortSignal.py
@@ -12,18 +12,18 @@ class BaseAbortSignal(ABC):
 
     @property
     def aborted(self) -> bool:
-        """Returns True if the signal has been aborted."""
+        """Return True if the signal has been aborted."""
         return self._aborted
 
     def add_listener(self, listener: Callable[[], None]) -> None:
-        """Adds a listener to be called when the signal is aborted."""
+        """Add a listener to be called when the signal is aborted."""
         if self._aborted:
             listener()
         else:
             self._listeners.append(listener)
 
     def remove_listener(self, listener: Callable[[], None]) -> None:
-        """Removes a previously added listener."""
+        """Remove a previously added listener."""
         if not self._aborted:
             self._listeners = [li for li in self._listeners if li != listener]
 
@@ -43,7 +43,7 @@ class AsyncAbortSignal(BaseAbortSignal):
         self._event = asyncio.Event()
 
     async def abort(self) -> None:
-        """Aborts the signal."""
+        """Abort the signal."""
         if not self._aborted:
             self._aborted = True
             for listener in self._listeners:
@@ -52,7 +52,7 @@ class AsyncAbortSignal(BaseAbortSignal):
             self._event.set()
 
     async def wait_for_abort(self) -> None:
-        """Waits for the signal to be aborted."""
+        """Wait for the signal to be aborted."""
         await self._event.wait()
 
 
@@ -63,7 +63,7 @@ class SyncAbortSignal(BaseAbortSignal):
         self._event = threading.Event()
 
     def abort(self) -> None:
-        """Aborts the signal."""
+        """Abort the signal."""
         if not self._aborted:
             self._aborted = True
             for listener in self._listeners:
@@ -72,5 +72,5 @@ class SyncAbortSignal(BaseAbortSignal):
             self._event.set()
 
     def wait_for_abort(self) -> None:
-        """Waits for the signal to be aborted."""
+        """Wait for the signal to be aborted."""
         self._event.wait()

--- a/src/lmstudio_sdk/utils/AbortSignal.py
+++ b/src/lmstudio_sdk/utils/AbortSignal.py
@@ -37,7 +37,13 @@ class BaseAbortSignal(ABC):
 
 
 class AsyncAbortSignal(BaseAbortSignal):
-    # TODO docstring
+    """An asynchronous signal that can be used to abort an operation.
+
+    Ported from the AbortSignal class in the JavaScript DOM API.
+    Unfortunately we have to distinguish between async/sync abort signals
+    due to the nature of calling listeners, but the interface is the same.
+    """
+
     def __init__(self):
         super().__init__()
         self._event = asyncio.Event()
@@ -57,7 +63,13 @@ class AsyncAbortSignal(BaseAbortSignal):
 
 
 class SyncAbortSignal(BaseAbortSignal):
-    # TODO docstring
+    """A synchronous signal that can be used to abort an operation.
+
+    Ported from the AbortSignal class in the JavaScript DOM API.
+    Unfortunately we have to distinguish between async/sync abort signals
+    due to the nature of calling listeners, but the interface is the same.
+    """
+
     def __init__(self):
         super().__init__()
         self._event = threading.Event()

--- a/src/lmstudio_sdk/utils/__init__.py
+++ b/src/lmstudio_sdk/utils/__init__.py
@@ -1,8 +1,21 @@
 # pylance: disable=unused-imports
 # flake8: noqa: f401
 # ruff: noqa: F401
+"""Utility functions/classes and ported TypeScript classes.
 
-# TODO docstring
+Classes:
+    AsyncAbortSignal: An asynchronous signal that can be used to abort an operation.
+    SyncAbortSignal:A synchronous signal that can be used to abort an operation.
+    ChannelError: An error that occurs during a channel operation.
+    RPCError: An error that occurs during an RPC call.
+
+Logging:
+    get_logger: A function to get a logger for the SDK.
+    RECV: Debug level for sent and received packets from the LM Studio server.
+    SEND: Debug level for sent packets to the LM Studio server
+    WEBSOCKET: Debug level for WebSocket connection events.
+"""
+
 from .AbortSignal import AsyncAbortSignal, SyncAbortSignal
 from .BufferedEvent import (
     AsyncBufferedEvent,

--- a/src/lmstudio_sdk/utils/utils.py
+++ b/src/lmstudio_sdk/utils/utils.py
@@ -27,7 +27,7 @@ def number_to_checkbox_numeric(
 
 # TODO: can you change indent on the fly?
 def pretty_print(obj):
-    """Pretty prints the object."""
+    """Pretty print the object."""
     try:
         return json.dumps(obj, indent=2, default=lambda x: str(x))
     except Exception:
@@ -49,12 +49,12 @@ def _assert(condition: bool, message: str, info: str, logger):
 
 
 class RPCError(Exception):
-    """Raised when an RPC call fails."""
+    """Error in an RPC call."""
     pass
 
 
 class ChannelError(Exception):
-    """Raised when an error occurs in the channel."""
+    """Error in a WebSocket channel."""
     pass
 
 

--- a/tests/ISSUES.md
+++ b/tests/ISSUES.md
@@ -1,3 +1,1 @@
 found:
-
-- guess base URL does not work in async client

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,63 +7,21 @@ logger.setLevel(10)
 async def main():
     llm_client = await LMStudioClient(base_url="ws://localhost:1234")
     try:
-        # model_path = "lmstudio-community/gemma-2-2b-it-GGUF/gemma-2-2b-it-Q8_0.gguf"
-        # model_path = "Qwen/Qwen2-0.5B-Instruct-GGUF/qwen2-0_5b-instruct-q4_0.gguf"
-        # model_path = "qwen2"
-
         print(await llm_client.system.list_downloaded_models())
-        return
-
-        # await llm_client.system.list_downloaded_models()
-
-        print("sdfaSs")
-
-        # result = await llm_client.getLoadConfig(model_path)
-        # model = await llm_client.llm.get("qwen2")
-        # signal = AbortSignal()
-        # try:
-        #    model = await (
-        #        await llm_client.llm.load(
-        #            "lmstudio-community/Qwen2-500M-Instruct-GGUF", {"config": {"context_length": 1000}}
-        #        )
-        #    )
-        # except Exception as e:
-        #    print("Failed to load model:", e)
 
         model = await llm_client.llm.get("qwen2")
-        # print("sleeping")
-        # await asyncio.sleep(1)
-        # await signal.abort()
-        # print("should be aborted")
-        # raise Exception("Test")
-        # model = await model
-        # print("Model loaded:", model)
-        # raise Exception("Test")
 
         result = await model.respond([{"role": "user", "content": "Tell me a long story."}], {})
-        print("Result:", result)
-        print(await result)
-        # result = await (await model.respond([{"role": "user", "content": "Say only the word 'hi'."}], {}))
-        # async for completion in result:
-        #    print(type(completion))
-        #    print("frag", completion)
-        # return
-        print(type(result))
-        # result = await llm_client.load_model(model_path)
-        print("Model loaded:", result)
+        # print(await result)
+        async for completion in result:
+            print(completion)
 
         tokenCount = await model.unstable_tokenize("Hello, how are you?")
         print("Token count:", tokenCount)
 
         contextLength = await model.unstable_get_context_length()
         print("Context length:", contextLength)
-
-        # async for completion in llm_client.predict(model_path):
-        #    print(completion)
-    # except Exception as e:
-    # print("Error:", e)
     finally:
-        # pass
         await llm_client.close()
 
 


### PR DESCRIPTION
Add docstrings to all public API classes, modules, and functions, as well as a few internal ones (notably the `ClientPort` family). Also brought the README up to literal parity with the TypeScript SDK by copy/pasting the examples and translating them. 😅 

Another small initiative this PR begins is that some dataclasses are only ever really instantiated internally, such as `PredictionResult`; right now everything is a `TypedDict`, but it would be best to move these to being regular classes so users can dot access fields. `ModelDescriptor` is probably next on the chopping block w.r.t. this.

I'm also reconsidering renaming everything to underscores instead of camelCase because it complicates conversion between server communications and the public API.